### PR TITLE
Make resolving path relative to package search across all paths in sys.path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Prepare tactus as a separate package from Deode-Workflow, which now belongs to ACCORD-NWP. [\#2](https://github.com/ACCORD-NWP/tactus/pull/2) (@mfroelund)
 - Make argparser be returned instead of parsed args to make it extendable. [\#3](https://github.com/ACCORD-NWP/tactus/pull/3) (@mfroelund)
+- Make resolving path relative to package search across all paths in sys.path. [\#4](https://github.com/ACCORD-NWP/tactus/pull/4) (@mfroelund)
 
 ## [0.25.0] - 2026-02-13
 

--- a/tactus/os_utils.py
+++ b/tactus/os_utils.py
@@ -7,11 +7,11 @@ import pathlib
 import re
 import shutil
 import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import List, Union
 
-from . import GeneralConstants
 from .logs import logger
 
 
@@ -300,10 +300,12 @@ def strip_off_mount_path(path: Union[str, Path]) -> Path:
 
 
 def resolve_path_relative_to_package(path: Path, ignore_errors: bool = False) -> Path:
-    """Resolve path relative to package directory.
+    """Resolve path relative to any sys.path entry.
 
-    If the path exists as is, return it. If not, check if it exists in the
-    package directory and return path relative to package
+    If the path exists as is, return it. If not, derive a relative path by
+    stripping known sys.path prefixes, then search every sys.path entry for
+    that relative path. Raises an error if more than one candidate is found
+    to avoid silent ambiguity.
 
     Args:
         path (Path): Path to resolve.
@@ -311,43 +313,49 @@ def resolve_path_relative_to_package(path: Path, ignore_errors: bool = False) ->
             Defaults to False.
 
     Raises:
-        FileNotFoundError: If it was impossible to determine path relative to package.
-        FileNotFoundError: If file does not exist locally or in the package directory.
+        FileNotFoundError: If the file is not found under any sys.path entry
+            and ignore_errors is False.
+        ValueError: If more than one candidate is found across sys.path entries.
 
     Returns:
         Path: Original path (if exists locally), or resolved path relative to
-            package directory.
+            a sys.path entry.
 
     """
     path = path.expanduser().resolve()
-    # First check if path exists as is
-    if not os.path.exists(path):
-        # Get path relative to package. Needed when tactus is installed as
-        # a site-package e.g. when creating plugins.
-        if GeneralConstants.PACKAGE_NAME in path.parts:
-            # Find last occurence of package name in path
-            package_index_in_path = (
-                len(path.parts)
-                - path.parts[::-1].index(GeneralConstants.PACKAGE_NAME)
-                - 1
-            )
-            # Stick together the path in the package directory
-            config_parts = path.parts[package_index_in_path:]
-            path = GeneralConstants.PACKAGE_DIRECTORY.parent / Path(*config_parts)
-        elif not ignore_errors:
-            raise FileNotFoundError(
-                f"Could not determine path {path} relative to the "
-                + f"{GeneralConstants.PACKAGE_NAME} package."
-            )
-
-        # If not, check if it exists in the package directory (used when
-        # tactus is installed as package)
-        if not os.path.exists(path) and not ignore_errors:
-            raise FileNotFoundError(
-                f"Config file {path} not found locally or in package directory"
-            )
+    if os.path.exists(path):
         return path
 
+    # For each sys.path entry that is a prefix of the given path, derive the
+    # relative portion and search all sys.path entries for it.
+    candidates = set()
+    for sys_path_str in sys.path:
+        if not sys_path_str:
+            continue
+        try:
+            rel_path = path.relative_to(sys_path_str)
+        except ValueError:
+            continue
+
+        for search_path_str in sys.path:
+            if not search_path_str:
+                continue
+            candidate = Path(search_path_str) / rel_path
+            if candidate.exists():
+                candidates.add(candidate)
+
+    if len(candidates) > 1:
+        raise ValueError(
+            f"Ambiguous path resolution for {path}. "
+            "Multiple candidates found across sys.path entries:\n"
+            + "\n".join(f"  {c}" for c in sorted(candidates))
+        )
+    if len(candidates) == 1:
+        return next(iter(candidates))
+    if not ignore_errors:
+        raise FileNotFoundError(
+            f"File {path} not found locally or relative to any sys.path entry"
+        )
     return path
 
 

--- a/tests/unit/test_os_utils.py
+++ b/tests/unit/test_os_utils.py
@@ -2,11 +2,20 @@
 
 import os
 import shutil
+import sys
 import tempfile
 from pathlib import Path
 from unittest import mock
 
-from tactus.os_utils import Search, ping, strip_off_mount_path, tactusmakedirs
+import pytest
+
+from tactus.os_utils import (
+    Search,
+    ping,
+    resolve_path_relative_to_package,
+    strip_off_mount_path,
+    tactusmakedirs,
+)
 
 
 class TestSearch:
@@ -213,3 +222,97 @@ class TestStripOffMountPath:
         expected_result = Path(f"/perm/{mock_user}/foo/bar")
 
         assert strip_off_mount_path(test_path) == expected_result
+
+
+class TestResolvePathRelativeToPackage:
+    """Test the resolve_path_relative_to_package function."""
+
+    def test_existing_path_returned_directly(self, tmp_path):
+        """A path that already exists on disk is returned as-is."""
+        f = tmp_path / "file.txt"
+        f.write_text("content")
+        assert resolve_path_relative_to_package(f) == f
+
+    def test_resolved_under_sys_path_entry(self, tmp_path):
+        """Path resolved to an existing file found under a different sys.path entry."""
+        real_base = tmp_path / "real_base"
+        (real_base / "pkg" / "data").mkdir(parents=True)
+        target = real_base / "pkg" / "data" / "file.txt"
+        target.write_text("content")
+
+        fake_base = tmp_path / "fake_base"
+        fake_path = fake_base / "pkg" / "data" / "file.txt"
+
+        with mock.patch.object(sys, "path", [str(fake_base), str(real_base)]):
+            result = resolve_path_relative_to_package(fake_path)
+
+        assert result == target
+
+    def test_not_found_raises_file_not_found(self, tmp_path):
+        """FileNotFoundError when the file is not found under any sys.path entry."""
+        fake_base = tmp_path / "fake_base"
+        real_base = tmp_path / "real_base"
+        real_base.mkdir()
+        fake_path = fake_base / "pkg" / "missing.txt"
+
+        with mock.patch.object(
+            sys, "path", [str(fake_base), str(real_base)]
+        ), pytest.raises(FileNotFoundError):
+            resolve_path_relative_to_package(fake_path)
+
+    def test_not_found_ignore_errors_returns_path(self, tmp_path):
+        """Returns the resolved path unchanged when not found and ignore_errors=True."""
+        fake_base = tmp_path / "fake_base"
+        fake_path = fake_base / "pkg" / "missing.txt"
+
+        with mock.patch.object(sys, "path", [str(fake_base)]):
+            result = resolve_path_relative_to_package(fake_path, ignore_errors=True)
+
+        assert result == fake_path.resolve()
+
+    def test_multiple_candidates_raises_value_error(self, tmp_path):
+        """ValueError when the relative path resolves under more than one sys.path entry."""
+        fake_base = tmp_path / "fake_base"
+        fake_path = fake_base / "pkg" / "data" / "file.txt"
+
+        for base_name in ("real_base_a", "real_base_b"):
+            base = tmp_path / base_name
+            (base / "pkg" / "data").mkdir(parents=True)
+            (base / "pkg" / "data" / "file.txt").write_text(base_name)
+
+        with mock.patch.object(
+            sys,
+            "path",
+            [
+                str(fake_base),
+                str(tmp_path / "real_base_a"),
+                str(tmp_path / "real_base_b"),
+            ],
+        ), pytest.raises(ValueError):
+            resolve_path_relative_to_package(fake_path)
+
+    def test_no_matching_sys_path_prefix_raises_file_not_found(self):
+        """FileNotFoundError when no sys.path entry is a prefix of the given path."""
+        path = Path("/totally/nonexistent/path/file.txt")
+        with mock.patch.object(sys, "path", ["/some/unrelated/path"]), pytest.raises(
+            FileNotFoundError
+        ):
+            resolve_path_relative_to_package(path)
+
+    def test_no_matching_sys_path_prefix_ignore_errors(self):
+        """Returns the resolved path unchanged when no prefix matches and ignore_errors=True."""
+        path = Path("/totally/nonexistent/path/file.txt")
+        with mock.patch.object(sys, "path", ["/some/unrelated/path"]):
+            result = resolve_path_relative_to_package(path, ignore_errors=True)
+
+        assert result == path.resolve()
+
+    def test_empty_sys_path_entries_are_skipped(self, tmp_path):
+        """Empty strings in sys.path are safely skipped."""
+        fake_base = tmp_path / "fake_base"
+        fake_path = fake_base / "file.txt"
+
+        with mock.patch.object(sys, "path", ["", str(fake_base), ""]), pytest.raises(
+            FileNotFoundError
+        ):
+            resolve_path_relative_to_package(fake_path)

--- a/tests/unit/test_os_utils.py
+++ b/tests/unit/test_os_utils.py
@@ -288,7 +288,7 @@ class TestResolvePathRelativeToPackage:
                 str(tmp_path / "real_base_a"),
                 str(tmp_path / "real_base_b"),
             ],
-        ), pytest.raises(ValueError):
+        ), pytest.raises(ValueError, match="Ambiguous path resolution for"):
             resolve_path_relative_to_package(fake_path)
 
     def test_no_matching_sys_path_prefix_raises_file_not_found(self):


### PR DESCRIPTION
## Describe your changes
This PR generalizes the  resolve_path_relative_to_package to look for a file in all directories of sys.path. This makes it possible, now that Deode-Workflow and tactus is being separated, to resolve relative paths located other places than in the tactus package. This is useful in Deode-Workflow-Monitoring, which will reference both tactus core configs and Deode-Workflow specific configs.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

### Testing


For further information see the [development guide](https://github.com/ACCORD-NWP/tactus/blob/develop/docs/markdown_docs/development_guide.md)

### Code quality

- [x] My change follows the [best practices for this project](https://github.com/ACCORD-NWP/tactus/blob/develop/docs/markdown_docs/development_guide.md#best-practices).
- [x] My local environment is correctly initialised as described in the [README](https://github.com/ACCORD-NWP/tactus/blob/develop/README.md) file.
- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation and docstrings to reflect the changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have ensured that the code is still installable with `poetry` after the changes and runs
- [x] I have requested one or more reviewer(s) and an assignee (assignee is responsible for merging). At least one reviewer has accepted to review.

## Checklist for reviewers
Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code readable
- [ ] the code well tested (checked coverage report)
- [ ] the code documented
- [ ] the code easy to maintain

## Author checklist after completed review

- [x] I have added a line to the CHANGELOG describing this change (in section
  reflecting type of change, for example "bug fixes", add section where
  missing)

## Checklist for assignees
- [x] PR is up to date with the base branch
- [x] the tests passing
- [x] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- [x] the PR has been approved by all the reviewers, that accepted to review.
- Once the PR ready to be merged, squash commits and merge the PR.

## Tag possible reviewers
You can @-tag people to review this PR in addition to formal review requests.
