### PR TITLE
Introudce a suite mirror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/destination-earth-digital-twins/Deode-Prototype/tree/HEAD)
 
 ### Added
+- Add suite mirror option [\#69](https://github.com/ACCORD-NWP/tactus/pull/69) (@uandrae)
 - Configuration files for NSC HPC Fahrenheit [\#16](https://github.com/ACCORD-NWP/tactus/pull/16) (@trygveasp)
 - Introduce gl namelist files for CY50T2 [\#35](https://github.com/ACCORD-NWP/tactus/pull/35) (@uandrae)
 - Introduce config files for CY50T2 [\#14](https://github.com/ACCORD-NWP/tactus/pull/14) (@uandrae)

--- a/tactus/data/config_files/config_file_schemas/main_config_schema.json
+++ b/tactus/data/config_files/config_file_schemas/main_config_schema.json
@@ -496,6 +496,11 @@
           "type": "boolean",
           "default": false
         },
+        "mirror_suite": {
+          "description": "Mirror system.host_suite and trigger when the PostMortem task is completed",
+          "type": "boolean",
+          "default": false
+        },
         "max_static_data_tasks": {
           "description": "Limit for max number of monthly tasks, run at same time",
           "type": "integer",

--- a/tactus/data/config_files/include/scheduler/ecflow_atos_bologna.toml
+++ b/tactus/data/config_files/include/scheduler/ecflow_atos_bologna.toml
@@ -13,6 +13,16 @@
 [scheduler.ecfvars.troika]
   config_file = "@ECF_TACTUS_HOME@/data/config_files/troika.yml"
 
+[scheduler.mirror_host_case]
+  check_var = ""
+  mirror_name = "host_case"
+  remote_auth = ""
+  remote_host = "_select_host_from_list(['ecfg-@USER@-1', 'ecflow-gen-@USER@-001'],)"
+  remote_path = "/@HOST_CASE@/@YYYY@@MM@@DD@/@HH@@mm@/mbr000/Cycle/Forecasting"
+  remote_polling = "300"
+  remote_port = "3141"
+  remote_ssl = false
+
 [scheduler.mirror_suite]
   check_var = ""
   mirror_name = "@HOST_SUITE@"

--- a/tactus/data/config_files/include/scheduler/ecflow_atos_bologna.toml
+++ b/tactus/data/config_files/include/scheduler/ecflow_atos_bologna.toml
@@ -13,12 +13,9 @@
 [scheduler.ecfvars.troika]
   config_file = "@ECF_TACTUS_HOME@/data/config_files/troika.yml"
 
-[scheduler.mirror_host_case]
-  check_var = ""
-  mirror_name = "host_case"
-  remote_auth = ""
-  remote_host = "_select_host_from_list(['ecfg-@USER@-1', 'ecflow-gen-@USER@-001'],)"
-  remote_path = "/@HOST_CASE@/@YYYY@@MM@@DD@/@HH@@mm@/mbr000/Cycle/Forecasting"
-  remote_polling = "300"
-  remote_port = "3141"
-  remote_ssl = false
+[scheduler.mirror_suite]
+  mirror_name = "@HOST_SUITE@"
+  remote_host = "@SCHEDULER.ECFVARS.ECF_HOST@"
+  remote_path = "/@HOST_SUITE@/PostMortem"
+  remote_polling = "120"
+  remote_port = "@SCHEDULER.ECFVARS.ECF_PORT@"

--- a/tactus/data/config_files/include/scheduler/ecflow_atos_bologna.toml
+++ b/tactus/data/config_files/include/scheduler/ecflow_atos_bologna.toml
@@ -14,8 +14,11 @@
   config_file = "@ECF_TACTUS_HOME@/data/config_files/troika.yml"
 
 [scheduler.mirror_suite]
+  check_var = ""
   mirror_name = "@HOST_SUITE@"
+  remote_auth = ""
   remote_host = "@SCHEDULER.ECFVARS.ECF_HOST@"
-  remote_path = "/@HOST_SUITE@/PostMortem"
+  remote_path = "/@HOST_SUITE@/Compilation/IalBundleBuild"
   remote_polling = "120"
   remote_port = "@SCHEDULER.ECFVARS.ECF_PORT@"
+  remote_ssl = false

--- a/tactus/suites/base.py
+++ b/tactus/suites/base.py
@@ -263,7 +263,7 @@ class EcflowNode:
             elif self.node_type == "suite":
                 self.ecf_node = parent.add_suite(self.name)
             elif self.node_type == "mirror":
-                if mirror_config["check_var"]:
+                if mirror_config.get("check_var", None):
                     variables = {mirror_config["check_var"]: "placeholder"}
                 self.ecf_node = parent.ecf_node.add_task(self.name)
             else:
@@ -396,8 +396,8 @@ class EcflowNode:
                     mirror_config["remote_host"],
                     mirror_config["remote_port"],
                     mirror_config["remote_polling"],
-                    mirror_config["remote_ssl"],
-                    mirror_config["remote_auth"],
+                    mirror_config.get("remote_ssl", False),
+                    mirror_config.get("remote_auth", ""),
                 )
             )
 

--- a/tactus/suites/base.py
+++ b/tactus/suites/base.py
@@ -396,8 +396,8 @@ class EcflowNode:
                     mirror_config["remote_host"],
                     mirror_config["remote_port"],
                     mirror_config["remote_polling"],
-                    mirror_config.get("remote_ssl", False),
-                    mirror_config.get("remote_auth", ""),
+                    mirror_config["remote_ssl"],
+                    mirror_config["remote_auth"],
                 )
             )
 

--- a/tactus/suites/tactus.py
+++ b/tactus/suites/tactus.py
@@ -3,9 +3,15 @@
 from pathlib import Path
 
 from tactus.os_utils import tactusmakedirs
-from tactus.suites.base import EcflowSuiteTask, SuiteDefinition
+from tactus.suites.base import (
+    EcflowSuiteTask,
+    EcflowSuiteTrigger,
+    EcflowSuiteTriggers,
+    SuiteDefinition,
+)
 from tactus.suites.tactus_suite_components import (
     CompilationFamily,
+    MirrorPostMortem,
     StaticDataFamily,
     TimeDependentFamily,
 )
@@ -58,12 +64,28 @@ class TactusSuiteDefinition(SuiteDefinition):
         # Construct the suite from individual ecFlow components
         final_cleaning_trigger = []
         time_dependent_trigger_node = None
+
+        mirror = None
+        if config["suite_control"].get("do_mirror_suite", False):
+            mirror = MirrorPostMortem(
+                self.suite,
+                config,
+                self.task_settings,
+                input_template,
+                self.ecf_files,
+                ecf_files_remotely=self.ecf_files_remotely,
+            )
+            mirror = EcflowSuiteTriggers([EcflowSuiteTrigger(mirror)])
+            mirror_path = config["scheduler.mirror_suite"]["remote_path"].split("/")[-1]
+            mirror.trigger_string = f"( /{self.name}/Mirrors/{mirror_path} == complete )"
+
         prep_run = EcflowSuiteTask(
             "PrepRun",
             self.suite,
             config,
             self.task_settings,
             self.ecf_files,
+            trigger=mirror,
             input_template=input_template,
             ecf_files_remotely=self.ecf_files_remotely,
         )

--- a/tactus/suites/tactus.py
+++ b/tactus/suites/tactus.py
@@ -11,7 +11,7 @@ from tactus.suites.base import (
 )
 from tactus.suites.tactus_suite_components import (
     CompilationFamily,
-    MirrorPostMortem,
+    MirrorSuite,
     StaticDataFamily,
     TimeDependentFamily,
 )
@@ -66,8 +66,8 @@ class TactusSuiteDefinition(SuiteDefinition):
         time_dependent_trigger_node = None
 
         mirror = None
-        if config["suite_control"].get("do_mirror_suite", False):
-            mirror = MirrorPostMortem(
+        if config["suite_control"].get("mirror_suite", False):
+            _mirror = MirrorSuite(
                 self.suite,
                 config,
                 self.task_settings,
@@ -75,9 +75,10 @@ class TactusSuiteDefinition(SuiteDefinition):
                 self.ecf_files,
                 ecf_files_remotely=self.ecf_files_remotely,
             )
-            mirror = EcflowSuiteTriggers([EcflowSuiteTrigger(mirror)])
-            mirror_path = config["scheduler.mirror_suite"]["remote_path"].split("/")[-1]
-            mirror.trigger_string = f"( /{self.name}/Mirrors/{mirror_path} == complete )"
+            mirror = EcflowSuiteTriggers([EcflowSuiteTrigger(_mirror)])
+            mirror.trigger_string = (
+                f"( /{self.name}/Mirrors/{_mirror.mirror_path} == complete )"
+            )
 
         prep_run = EcflowSuiteTask(
             "PrepRun",

--- a/tactus/suites/tactus_suite_components.py
+++ b/tactus/suites/tactus_suite_components.py
@@ -578,8 +578,15 @@ class MirrorPostMortem(EcflowSuiteFamily):
             ecf_files_remotely=ecf_files_remotely,
         )
 
+        # Resolve macros
+        platform = Platform(config)
+        self.mirror_suite = {
+            x: platform.substitute(y) for x, y in config["scheduler.mirror_suite"].items()
+        }
+        self.mirror_path = self.mirror_suite["remote_path"].split("/")[-1]
+
         EcflowSuiteTask(
-            config["scheduler.mirror_suite"]["remote_path"].split("/")[-1],
+            self.mirror_path,
             self,
             config,
             task_settings,
@@ -587,9 +594,11 @@ class MirrorPostMortem(EcflowSuiteFamily):
             input_template=input_template,
             trigger=[trigger],
             mirror=True,
-            mirror_config=config["scheduler.mirror_suite"],
+            mirror_config=self.mirror_suite,
             ecf_files_remotely=ecf_files_remotely,
         )
+
+        #self.trigger_string = f"( /{parent.name}/Mirrors/{mirror_path} == complete )"
 
 
 class InputDataFamily(EcflowSuiteFamily):

--- a/tactus/suites/tactus_suite_components.py
+++ b/tactus/suites/tactus_suite_components.py
@@ -556,6 +556,42 @@ class MirrorFamily(EcflowSuiteFamily):
             )
 
 
+class MirrorPostMortem(EcflowSuiteFamily):
+    """Class for waiting for a suite."""
+
+    def __init__(
+        self,
+        parent,
+        config,
+        task_settings: TaskSettings,
+        input_template,
+        ecf_files,
+        trigger=None,
+        ecf_files_remotely=None,
+    ):
+        """Class initialization."""
+        super().__init__(
+            "Mirrors",
+            parent,
+            ecf_files,
+            trigger=trigger,
+            ecf_files_remotely=ecf_files_remotely,
+        )
+
+        EcflowSuiteTask(
+            config["scheduler.mirror_suite"]["remote_path"].split("/")[-1],
+            self,
+            config,
+            task_settings,
+            ecf_files,
+            input_template=input_template,
+            trigger=[trigger],
+            mirror=True,
+            mirror_config=config["scheduler.mirror_suite"],
+            ecf_files_remotely=ecf_files_remotely,
+        )
+
+
 class InputDataFamily(EcflowSuiteFamily):
     """Class for creating the InputDataFamily ecFlow family."""
 

--- a/tactus/suites/tactus_suite_components.py
+++ b/tactus/suites/tactus_suite_components.py
@@ -16,6 +16,7 @@ from tactus.datetime_utils import (
 )
 from tactus.host_actions import SelectHost
 from tactus.logs import logger
+from tactus.scheduler import EcflowServer
 from tactus.submission import ProcessorLayout, TaskSettings
 from tactus.suites.base import (
     EcflowSuiteFamily,
@@ -556,7 +557,7 @@ class MirrorFamily(EcflowSuiteFamily):
             )
 
 
-class MirrorPostMortem(EcflowSuiteFamily):
+class MirrorSuite(EcflowSuiteFamily):
     """Class for waiting for a suite."""
 
     def __init__(
@@ -578,11 +579,18 @@ class MirrorPostMortem(EcflowSuiteFamily):
             ecf_files_remotely=ecf_files_remotely,
         )
 
-        # Resolve macros
+        # Resolve macros, host and port
         platform = Platform(config)
         self.mirror_suite = {
-            x: platform.substitute(y) for x, y in config["scheduler.mirror_suite"].items()
+            x: v if isinstance(v := platform.substitute(y), (str, bool)) else str(v)
+            for x, y in config["scheduler.mirror_suite"].items()
         }
+        self.mirror_suite["remote_host"] = platform.evaluate(
+            self.mirror_suite["remote_host"], object_=SelectHost
+        )
+        self.mirror_suite["remote_port"] = platform.evaluate(
+            self.mirror_suite["remote_port"], object_=EcflowServer
+        )
         self.mirror_path = self.mirror_suite["remote_path"].split("/")[-1]
 
         EcflowSuiteTask(
@@ -597,8 +605,6 @@ class MirrorPostMortem(EcflowSuiteFamily):
             mirror_config=self.mirror_suite,
             ecf_files_remotely=ecf_files_remotely,
         )
-
-        #self.trigger_string = f"( /{parent.name}/Mirrors/{mirror_path} == complete )"
 
 
 class InputDataFamily(EcflowSuiteFamily):


### PR DESCRIPTION
## Describe your changes
Introduces a suite mirror family before PrepRun to allow suite -> suite triggering. The primary usage is for testing where e.g. CY50t2 compilation can be separated from the rest of the runs. Similar could be done for climate files, boundary interpolation etc.

For an example of usage we can start a compilation suite

```
tactus case tactus/data/config_files/configurations/cy50t2_arome modifs.toml --start-suite 
```
where `modifs.toml` contains

```
[general]
  case = "cy50_compile"

[suite_control]
  suite_definition = "CompilationSuiteDefinition"
  compile = false

```

We can now start the following suite with the modification below

```
[suite_control]
  mirror_suite = true
  compile = false

[system]
  host_suite = "cy50_compile"

[general.times]
  end = "P0D"
  start = "P0D"

[scheduler.mirror_suite]
  remote_path = "/@HOST_SUITE@/Compilation"

[submission]
  bindir = "@CASEDIR@/../@HOST_SUITE@/install/bin"
```


< Please also include relevant motivation and context. >

< List any dependencies that are required for this change. >

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

### Testing

- [ ] I have tested this on ATOS using the `atos_bologna.toml` configuration in the latest version of [Tactus-test-runner](https://github.com/destination-earth-digital-twins/Tactus-test-runner)
- [ ] I have tested this on LUMI using the `lumi.toml` configuration in the latest version of [Tactus-test-runner](https://github.com/destination-earth-digital-twins/Tactus-test-runner)

For further information see the [development guide](https://github.com/ACCORD-NWP/tactus/blob/develop/docs/markdown_docs/development_guide.md)

### Code quality

- [ ] My change follows the [best practices for this project](https://github.com/ACCORD-NWP/tactus/blob/develop/docs/markdown_docs/development_guide.md#best-practices).
- [ ] My local environment is correctly initialised as described in the [README](https://github.com/ACCORD-NWP/tactus/blob/develop/README.md) file.
- [ ] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation and docstrings to reflect the changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have ensured that the code is still installable with `poetry` after the changes and runs
- [ ] I have requested one or more reviewer(s) and an assignee (assignee is responsible for merging). At least one reviewer has accepted to review.

## Checklist for reviewers
Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code readable
- [ ] the code well tested (checked coverage report)
- [ ] the code documented
- [ ] the code easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change (in section
  reflecting type of change, for example "bug fixes", add section where
  missing)

## Checklist for assignees
- [ ] PR is up to date with the base branch
- [ ] the tests passing
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- [ ] the PR has been approved by all the reviewers, that accepted to review.
- Once the PR ready to be merged, squash commits and merge the PR.

## Tag possible reviewers
You can @-tag people to review this PR in addition to formal review requests.
