### PR TITLE
Create Marsobs task to get conventional observations from MARS

### DIFF
--- a/CY50t2_AROME_DEMO_60x80_2500m_20250209.toml
+++ b/CY50t2_AROME_DEMO_60x80_2500m_20250209.toml
@@ -216,14 +216,12 @@
   bator_window_shift = -90
   bgcycle = ""
   const_dir = "@SCRATCH@/da/const"
-  do_upper_air = true
   gpssol_stations = []
   guess_dir = "@SCRATCH@/da/@CASE@/guess"
   namelist_dir = "@SCRATCH@/da/namelists"
   nbpool = 16
   obs_dir = "@SCRATCH@/da/@CASE@/obs"
   obs_provider = "LACE"
-  obs_step = 0
   obs_types_3dvar = [
     "synop",
     "gpssol",
@@ -246,10 +244,6 @@
 
 [da.oops]
   namelist_dir = "@SCRATCH@/da/oops_namelists"
-  niter = 66
-  nproma = -32
-  nsimu = 69
-  rednmc = 0.5
 
 [da.providers]
 
@@ -390,21 +384,21 @@
   gridtype_oro = ""
   ilate = 11
   ilone = 11
-  name = "DKCOEXP"
+  name = "DEMO_60x80_2500m"
   nbzong = -1
   nbzonl = -1
-  nimax = 637
-  njmax = 637
+  nimax = 49
+  njmax = 69
   number = ""
   orographic_smoothing_method = "truncation"
   tstep = 75
   xbeta = 0.0
   xdx = 2500
   xdy = 2500
-  xlat0 = 56.3
-  xlatcen = 56.3
-  xlon0 = 0.0
-  xloncen = 9.9
+  xlat0 = ""
+  xlatcen = 51.967
+  xlon0 = ""
+  xloncen = 4.9
 
 [domain.spectral_smoothing_by_gridtype]
   cubic = false
@@ -474,7 +468,7 @@
   databridge_user = "@PROD_USER@"
 
 [fdb.grib_set]
-  georef = "u4p033"
+  georef = "u15rxs"
   stream = "oper"
 
 [file_templates]
@@ -516,10 +510,10 @@
   model = "ICMSH@CNMEXP@+@DURATION_MODEL@"
 
 [file_templates.initfile]
-  archive = "@SCRATCH@/tactus/@PREV_CASE@/archive/@YYYY@/@MM@/@DD@/@HH@/@MEMBER_STR@/@HISTORY_TEMPLATE@"
+  archive = "@SCRATCH@/@SYS_NAME@/@PREV_CASE@/archive/@YYYY@/@MM@/@DD@/@HH@/@MEMBER_STR@/@HISTORY_TEMPLATE@"
 
 [file_templates.initfile_sfx]
-  archive = "@SCRATCH@/tactus/@PREV_CASE@/archive/@YYYY@/@MM@/@DD@/@HH@/@MEMBER_STR@/@SURFEX_TEMPLATE@"
+  archive = "@SCRATCH@/@SYS_NAME@/@PREV_CASE@/archive/@YYYY@/@MM@/@DD@/@HH@/@MEMBER_STR@/@SURFEX_TEMPLATE@"
 
 [file_templates.interpolated_boundaries]
   archive = "ELSCF@CNMEXP@ALBC@NNN@"
@@ -571,7 +565,7 @@
   member = 0
   member_str = "mbr000"
   remove_sections = []
-  start_etime = "1779962197.158219"
+  start_etime = "1779982388.1289935"
   surfex = true
   surfex_sea_ice = "sice"
   upd_sst_sic = true
@@ -592,11 +586,9 @@
   start = "2025-02-09T00:00:00Z"
 
 [git_info]
-  branch = "bstrajnar_develop_pau"
-  commit = "7fe2f45ed3285b8fff2e4ca132ffc75d50f2f3d1"
-  describe = "7fe2f45e-dirty"
-  remote = "bstrajnar/bstrajnar_develop"
-  remote_url = "git@github.com:bstrajnar/tactus.git"
+  branch = "feture_marsobs"
+  commit = "2eb049e66b7cd038f450216f54ce4aee48cd83f6"
+  describe = "2eb049e6-dirty"
 
 [gribmodify]
   conversions = ["fullpos"]
@@ -824,7 +816,7 @@
   GG_skt = "235"
   GG_snow = "33/238/228038/228141"
   GG_soil = "234/173/174/43/30/29/28/27"
-  GGZ_type = "CF"
+  GGZ_type = "AN"
   grid_ML = "AV"
   ifs_cycle_length = "PT6H"
   ifs_cycle_start = "PT0H"
@@ -832,11 +824,12 @@
   resolution = "9"
   SH = "152/138/155/130"
   SHZ = "129.128"
-  SHZ_type = "CF"
+  SHZ_type = "AN"
   start_date = "1900-01-01T00:00:00Z"
   start_snow_date = "2023-06-27T00:00:00Z"
   stream = "ENFO"
-  type_AN = "CF"
+  stream_control = "OPER"
+  type_AN = "FC"
   type_FC = "PF"
   UA = "133/75/76/246/247/248"
   Zlev_type = "ML"
@@ -969,7 +962,7 @@
   albnir_veg_dir = "@CLIMDATA@/ECOCLIMAP-SG/ALB_SAT"
   albvis_soil_dir = "@CLIMDATA@/ECOCLIMAP-SG/ALB_SAT"
   albvis_veg_dir = "@CLIMDATA@/ECOCLIMAP-SG/ALB_SAT"
-  archive_root = "@SCRATCH@/tactus/@CASE@/archive"
+  archive_root = "@SCRATCH@/@SYS_NAME@/@CASE@/archive"
   archive_types = ["compress", "copy", "ecfs", "fdb"]
   climdata = "@STATIC_DATA@/climate"
   e923_data = "@STATIC_DATA@/climate/E923_DATA"
@@ -986,9 +979,9 @@
   ncdir = "@STATIC_DATA@/ncdir"
   osm_data_eu = "@CLIMDATA@/OSM_SFX8_1_EU/GARDEN/"
   pgd_data_path = "@CLIMDATA@/PGD"
-  reference_data = "@SCRATCH@/tactus"
-  references_folder = "@SCRATCH@/tactus_references"
-  references_generation_folder = "@SCRATCH@/tactus_generated_references"
+  reference_data = "@SCRATCH@/@SYS_NAME@"
+  references_folder = "@SCRATCH@/@SYS_NAME@/references"
+  references_generation_folder = "@SCRATCH@/@SYS_NAME@/generated_references"
   rrtm_dir = "@STATIC_DATA@/rrtm/@CYCLE@"
   rttov_coefdir = "@STATIC_DATA@/satellite/rtcoef_rttov13/coef/"
   scratch = "/scratch/@USER@"
@@ -1106,13 +1099,13 @@
 
 [scheduler.ecfvars]
   case_prefix = ""
-  ecf_files = "@HOME@/tactus_ecflow/ecf_files"
-  ecf_files_remotely = "@HOME@/tactus_ecflow/ecf_files"
-  ecf_home = "@HOME@/tactus_ecflow/jobout"
+  ecf_files = "@HOME@/@SYS_NAME@_ecflow/ecf_files"
+  ecf_files_remotely = "@HOME@/@SYS_NAME@_ecflow/ecf_files"
+  ecf_home = "@HOME@/@SYS_NAME@_ecflow/jobout"
   ecf_host = "_select_host_from_list(['ecfg-@USER@-1', 'ecflow-gen-@USER@-001'],)"
   ecf_host_resolved = ""
-  ecf_jobout = "@HOME@/tactus_ecflow/jobout"
-  ecf_out = "@HOME@/tactus_ecflow/jobout"
+  ecf_jobout = "@HOME@/@SYS_NAME@_ecflow/jobout"
+  ecf_out = "@HOME@/@SYS_NAME@_ecflow/jobout"
   ecf_port = 3141
   ecf_port_resolved = ""
   ecf_remoteuser = ""
@@ -1132,6 +1125,16 @@
   remote_path = "/@HOST_CASE@/@YYYY@@MM@@DD@/@HH@@mm@/mbr000/Cycle/Forecasting"
   remote_polling = "300"
   remote_port = "3141"
+  remote_ssl = false
+
+[scheduler.mirror_suite]
+  check_var = ""
+  mirror_name = "@HOST_SUITE@"
+  remote_auth = ""
+  remote_host = "@SCHEDULER.ECFVARS.ECF_HOST@"
+  remote_path = "/@HOST_SUITE@/Compilation/IalBundleBuild"
+  remote_polling = "120"
+  remote_port = "@SCHEDULER.ECFVARS.ECF_PORT@"
   remote_ssl = false
 
 [submission]
@@ -1262,7 +1265,6 @@
   ECMWFTOOLBOX = ["load", "ecmwf-toolbox/2026.01.0.0"]
 
 [submission.task_exceptions.Forecast]
-  bindir = "@INSTALL_DIR@/@CYCLE@/@COMPILER@/@PRECISION@/@IAL_VERSION@/bin"
   NPROC = 30
   NPROC_IO = 2
 
@@ -1424,51 +1426,6 @@
   tasks = ["Background_vm"]
   WRAPPER = ""
 
-[submission.types.GMKPACK_EXECUTABLES]
-  NPROC = 1
-  NPROC_IO = 0
-  NPROCX = 1
-  NPROCY = 1
-  SCHOST = "hpc"
-  tasks = [
-    "Bator_synop",
-    "Bator_gpssol",
-    "Bator_amdr",
-    "Bator_geowind",
-    "Bator_temp",
-    "Bator_wp",
-    "Bator_seviri",
-    "Bator_amsua",
-    "Bator_amsub",
-    "Bator_iasi",
-    "Bator_ascat",
-    "OdbMerge",
-  ]
-  WRAPPER = "srun"
-
-[submission.types.GMKPACK_EXECUTABLES.BATCH]
-  NAME = "#SBATCH --job-name=@TASK_NAME@"
-  NODES = "#SBATCH --nodes=1"
-  NTASKS = "#SBATCH --ntasks=1"
-  QOS = "#SBATCH --qos=nf"
-  WALLSIGNAL = "#SBATCH --signal=USR1@30"
-  WALLTIME = "#SBATCH --time=00:15:00"
-
-[submission.types.GMKPACK_EXECUTABLES.ENV]
-  DR_HOOK_IGNORE_SIGNALS = -1
-  OMP_NUM_THREADS = 1
-  OMPI_MCA_btl = "^vader"
-
-[submission.types.GMKPACK_EXECUTABLES.MODULES]
-  00_PRGENV = ["load", "prgenv/intel"]
-  01_INTEL = ["load", "intel/2023.2.0"]
-  ECMWFTOOLBOX = ["load", "ecmwf-toolbox/2026.01.0.0"]
-  FFTW = ["load", "fftw/3.3.10"]
-  HDF5 = ["load", "hdf5/1.14.6"]
-  MKL = ["load", "intel-mkl/19.0.5"]
-  NETCDF = ["load", "netcdf4/4.9.3"]
-  OPENMPI = ["load", "openmpi/4.1.1.1"]
-
 [submission.types.gnu]
   NPROC = 1
   NPROC_IO = 0
@@ -1577,6 +1534,7 @@
   mirror_globalDT = false
   mirror_host_case = false
   mirror_offline = false
+  mirror_suite = false
   mode = "cold_start"
   n_addcalculatedfields = 2
   n_creategrib = 2
@@ -1593,7 +1551,7 @@
   bddir_sfx = "@BDDIR@"
   bddir_sst = "@BDDIR@"
   c903_input_definition = "@CYCLE@/c903.json"
-  casedir = "@SCRATCH@/tactus/@CASE@"
+  casedir = "@SCRATCH@/@SYS_NAME@/@CASE@"
   climdir = "@CASEDIR@/climate/@DOMAIN@"
   e923_input_definition = "@CYCLE@/e923.json"
   e927_input_definition = "@CYCLE@/e927.json"
@@ -1605,6 +1563,7 @@
   namelists = "@TACTUS_HOME@/data/namelists/@CYCLE@"
   prev_case = "@CASE@"
   sfx_input_definition = "@CYCLE@/sfx.json"
+  sys_name = "tactus"
   wrk = "@CASEDIR@/@YYYY@@MM@@DD@_@HH@@mm@"
 
 [troika]

--- a/CY50t2_AROME_DKCOEXP_20250209.toml
+++ b/CY50t2_AROME_DKCOEXP_20250209.toml
@@ -1,0 +1,1801 @@
+[archiving]
+
+[archiving.FDB.fdb.fpgrib_files]
+  active = false
+  inpath = "@ARCHIVE@"
+  pattern = "GRIBPF*"
+
+[archiving.hour]
+
+[archiving.hour.copy.config]
+  active = true
+  inpath = ""
+  newname = "config.toml"
+  outpath = "@ARCHIVE@"
+  pattern = "@CONFIG@"
+
+[archiving.hour.ecfs]
+
+[archiving.hour.ecfs.config]
+  active = true
+  inpath = "@ARCHIVE@"
+  outpath = "archive/@ARCHIVE_TIMESTAMP@/@MEMBER_STR@"
+  pattern = "config.toml"
+
+[archiving.hour.ecfs.ddh]
+  active = false
+  inpath = "@ARCHIVE@"
+  outpath = "archive/@ARCHIVE_TIMESTAMP@/@MEMBER_STR@"
+  pattern = "DHF*.tar.gz"
+
+[archiving.hour.ecfs.fa_files]
+  active = true
+  inpath = "@ARCHIVE@"
+  outpath = "archive/@ARCHIVE_TIMESTAMP@/@MEMBER_STR@"
+  pattern = "ICMSH*"
+
+[archiving.hour.ecfs.fpgrib_files]
+  active = true
+  inpath = "@ARCHIVE@"
+  outpath = "archive/@ARCHIVE_TIMESTAMP@/@MEMBER_STR@"
+  pattern = "GRIBPF*"
+
+[archiving.hour.ecfs.glgrib_files]
+  active = true
+  inpath = "@ARCHIVE@"
+  outpath = "archive/@ARCHIVE_TIMESTAMP@/@MEMBER_STR@"
+  pattern = "GRIB@CNMEXP@*"
+
+[archiving.hour.ecfs.sqlite]
+  active = "@SUITE_CONTROL.DO_EXTRACTSQLITE@"
+  inpath = "@SQLITE_PATH@"
+  outpath = "sqlite/@MEMBER_STR@"
+  pattern = "*"
+
+[archiving.hourlogs.ecfs.logs]
+  active = true
+  inpath = "@LOGS@"
+  outpath = "logs/@MEMBER_STR@"
+  pattern = "@YYYY@@MM@@DD@_@HH@@mm@.tar.gz"
+
+[archiving.merged_sqlite.ecfs.merged_sqlite]
+  active = "@SUITE_CONTROL.DO_MERGESQLITE@"
+  inpath = "@MERGED_SQLITE_PATH@"
+  outpath = "merged_sqlite"
+  pattern = "*"
+
+[archiving.prefix]
+  ecfs = "ec:/@USER@/tactus/@CASE@"
+
+[archiving.static.ecfs]
+
+[archiving.static.ecfs.climate_files]
+  active = true
+  inpath = "@CLIMDIR@"
+  outpath = "climate/@DOMAIN@/@MEMBER_STR@"
+  pattern = ["Const.Clim*", "PGD*"]
+
+[archiving.static.ecfs.config]
+  active = true
+  inpath = "@ARCHIVE_ROOT@"
+  outpath = ""
+  pattern = ["config.toml", "expanded_config.toml"]
+
+[archiving.staticlogs.ecfs.logs]
+  active = true
+  inpath = "@LOGS@"
+  outpath = "logs"
+  pattern = "StaticData.tar.gz"
+
+[archiving.staticmember.ecfs.climate_files]
+  active = true
+  inpath = "@CLIMDIR@"
+  outpath = "climate/@DOMAIN@/@MEMBER_STR@"
+  pattern = ["Const.Clim*", "PGD*"]
+
+[boundaries]
+  bd_has_surfex = false
+  bdint = "PT1H"
+  bdmodel = "ifs"
+  bdmodel_sfx = "from_grib"
+  bdshift = "PT0H"
+  bdshift_sfx = "PT0H"
+  do_slaf = false
+  humi_gp = true
+  lbc_per_task = 7
+  max_interpolation_tasks = 10
+  slafdiff = "PT0H"
+  slafk = 1.0
+  slaflag = "PT0H"
+  sst_is_lsm = "auto"
+  sstmodels = ["IFS"]
+
+[boundaries.ifs]
+  bdmember = []
+  selection = "HRES"
+
+[boundaries.lam]
+  bdcycle = "PT24H"
+  bdcycle_start = "PT0H"
+
+[clean_old_data]
+  cases_period = "P7D"
+  dw_case_prefixes = ["AUTOMATED_RUN", "HARMONIE_AROME", "AROME", "ALARO"]
+  force_delete_period = "P365D"
+  ignore = []
+  scratch_ext = "tactus"
+
+[cleaning]
+
+[cleaning.CycleCleaning]
+
+[cleaning.CycleCleaning.archive]
+  ncycles_delay = 4
+  path = "@ARCHIVE@"
+  wipe = true
+
+[cleaning.CycleCleaning.ecf_out]
+  path = "@ECF_OUT@/@CASE@/@YMD@/@HH@@mm@"
+  wipe = true
+
+[cleaning.CycleCleaning.ifs]
+  active = false
+  ncycles_delay = 4
+  path = "@REFERENCE_DATA@/IFS/@MARS_SELECTION@/@YYYY@/@MM@/@DD@"
+  step = "P1D"
+
+[cleaning.CycleCleaning.wrk]
+  ncycles_delay = 1
+  path = "@WRK@"
+  wipe = true
+
+[cleaning.defaults]
+  active = true
+  dry_run = false
+  include = "(.*)"
+  ncycles_delay = 1
+  path = ""
+  wipe = false
+
+[cleaning.PostMortem]
+
+[cleaning.PostMortem.ecf_files]
+  active = false
+  exclude = "(.*)PostMortem(.*)"
+  path = "@ECF_FILES@/@CASE@"
+
+[cleaning.PostMortem.ecf_out]
+  active = false
+  exclude = "(.*)PostMortem(.*)"
+  path = "@ECF_OUT@/@CASE@"
+
+[cleaning.PrepRun.ecf_out]
+  exclude = "(.*)PrepRun(.*)"
+  ncycles_delay = 0
+  path = "@ECF_OUT@/@CASE@"
+
+[collectlogs]
+
+[collectlogs.hourlogs]
+  joboutdir = "@ECF_OUT@/@CASE@/@YYYY@@MM@@DD@/@HH@@mm@"
+  tarname = "@YYYY@@MM@@DD@_@HH@@mm@"
+  task_logs = "@WRK@"
+
+[collectlogs.staticlogs]
+  joboutdir = "@ECF_OUT@/@CASE@/StaticData"
+  tarname = "StaticData"
+  task_logs = "@CLIMDIR@"
+
+[compile]
+  arch = "ecmwf/hpc2020"
+  git_branch = "develop"
+  git_repo = "git@github.com:ACCORD-NWP/IAL"
+  git_token = ""
+  ial_dir = "@CASEDIR@/IAL"
+
+[creategrib]
+
+[creategrib.CreateGrib]
+  conversions = []
+
+[creategrib.CreateGrib.surfex]
+  namelist = ["stepunits='h'"]
+  output_format = "GRIB"
+
+[creategrib.CreateGribStatic.pgd]
+  files_in = ["@CLIMDIR@/@PGD_ARCHIVE@"]
+  files_out = ["@CLIMDIR@/@PGD_ARCHIVE@.grib1"]
+  namelist = []
+  output_format = "GRIB"
+
+[da]
+  analysis_dir = "@SCRATCH@/da/@CASE@/analysis"
+  bator_nbslot = 1
+  bator_slot_len = 0
+  bator_window_len = 180
+  bator_window_shift = -90
+  bgcycle = ""
+  const_dir = "@SCRATCH@/da/const"
+  do_upper_air = true
+  gpssol_stations = []
+  guess_dir = "@SCRATCH@/da/@CASE@/guess"
+  namelist_dir = "@SCRATCH@/da/namelists"
+  nbpool = 16
+  obs_dir = "@SCRATCH@/da/@CASE@/obs"
+  obs_provider = "LACE"
+  obs_step = 0
+  obs_types_3dvar = [
+    "synop",
+    "gpssol",
+    "amdr",
+    "geowind",
+    "temp",
+    "wp",
+    "seviri",
+    "amsua",
+    "amsub",
+    "iasi",
+    "ascat",
+  ]
+  obs_types_surface = ["synop"]
+  obsoul_merge_script = "/perm/sis/tactus_bin/@CYCLE@/@COMPILER@/@PRECISION@/bin/obsoul_merge.pl"
+  openmp = true
+  rttov_coef_dir = "@RTTOV_COEFDIR@"
+  scratch = "@SCRATCH@/da/@CASE@/scratch"
+  varbc_dir = "@SCRATCH@/da/@CASE@/varbc"
+
+[da.oops]
+  namelist_dir = "@SCRATCH@/da/oops_namelists"
+  niter = 66
+  nproma = -32
+  nsimu = 69
+  rednmc = 0.5
+
+[da.providers]
+
+[da.providers.LACE]
+  obs_step = 60
+
+[da.providers.LACE.amdr]
+  candidates = ["obsoul_2_xxxxxx_xx_{ymdrr}", "obsoul_2_ehs_eu_{ymdrr}"]
+  local_name = "OBSOUL.amdr"
+
+[da.providers.LACE.amsua]
+  candidates = [
+    "bufr_7_amsua_metopc_{ymdrr}",
+    "bufr_7_amsua_metopb_{ymdrr}",
+    "bufr_7_amsua_noaa18_{ymdrr}",
+    "bufr_7_amsua_noaa19_{ymdrr}",
+  ]
+  local_name = "BUFR.amsua"
+
+[da.providers.LACE.amsub]
+  candidates = [
+    "bufr_7_mhs_metopc_{ymdrr}",
+    "bufr_7_mhs_metopb_{ymdrr}",
+    "bufr_7_mhs_noaa19_{ymdrr}",
+  ]
+  local_name = "BUFR.amsub"
+
+[da.providers.LACE.ascat]
+  candidates = ["bufr_9_ascatC_metopb_{ymdrr}", "bufr_9_ascatC_metopc_{ymdrr}"]
+  local_name = "BUFR.ascat"
+
+[da.providers.LACE.geowind]
+  candidates = ["bufr_3_geowind_xx_{ymdrr}"]
+  local_name = "BUFR.geowind"
+
+[da.providers.LACE.gpssol]
+  candidates = ["bufr_1_ztd_egvap_{ymdrr}"]
+  local_name = "BUFR.gpssol"
+
+[da.providers.LACE.iasi]
+  candidates = ["bufr_7_iasi_metopb_{ymdrr}", "bufr_7_iasi_metopc_{ymdrr}"]
+  local_name = "BUFR.iasi"
+
+[da.providers.LACE.seviri]
+  candidates = ["netcdf_7_seviri_xx_{ymdrr}"]
+  local_name = "NETCDF.seviri"
+  obs_step = 0
+
+[da.providers.LACE.synop]
+  candidates = [
+    "obsoul_1_xxxxxx_hu_{ymdrr}",
+    "obsoul_1_xxxxxy_hu_{ymdrr}",
+    "obsoul_1_xxxxxy_at_{ymdrr}",
+    "obsoul_1_xxxxxy_cz_{ymdrr}",
+    "obsoul_1_xxxxxy_sk_{ymdrr}",
+    "obsoul_1_xxxxxy_ro_{ymdrr}",
+    "obsoul_1_xxxxxy_si_{ymdrr}",
+    "obsoul_1_xxxxxy_cr_{ymdrr}",
+    "obsoul_1_xxxxxy_pl_{ymdrr}",
+  ]
+  local_name = "OBSOUL.synop"
+  obs_step = 0
+
+[da.providers.LACE.temp]
+  candidates = ["obsoul_5_xxxxxx_xx_{ymdrr}"]
+  local_name = "OBSOUL.temp"
+
+[da.providers.LACE.wp]
+  candidates = ["obsoul_6_xxxxxx_xx_{ymdrr}"]
+  local_name = "OBSOUL.wp"
+
+[da.providers.MF]
+  obs_step = 60
+
+[da.providers.UWC]
+  obs_step = 60
+
+[da.providers.UWC.amdr]
+  candidates = ["obsoul_2_xxxxxx_xx_{ymdrr}"]
+  local_name = "OBSOUL.amdr"
+
+[da.providers.UWC.amsua]
+  candidates = [
+    "bufr_7_amsua_metopc_{ymdrr}",
+    "bufr_7_amsua_metopb_{ymdrr}",
+    "bufr_7_amsua_noaa18_{ymdrr}",
+    "bufr_7_amsua_noaa19_{ymdrr}",
+  ]
+  local_name = "BUFR.amsua"
+
+[da.providers.UWC.amsub]
+  candidates = [
+    "bufr_7_mhs_metopc_{ymdrr}",
+    "bufr_7_mhs_metopb_{ymdrr}",
+    "bufr_7_mhs_noaa19_{ymdrr}",
+  ]
+  local_name = "BUFR.amsub"
+
+[da.providers.UWC.ascat]
+  candidates = ["bufr_9_ascatC_metopb_{ymdrr}", "bufr_9_ascatC_metopc_{ymdrr}"]
+  local_name = "BUFR.ascat"
+
+[da.providers.UWC.geowind]
+  candidates = ["obsoul_3_xxxxxx_xx_{ymdrr}"]
+  local_name = "OBSOUL.geowind"
+
+[da.providers.UWC.gpssol]
+  candidates = ["obsoul_9_xxxxxx_xx_{ymdrr}"]
+  local_name = "OBSOUL.gpssol"
+
+[da.providers.UWC.iasi]
+  candidates = ["bufr_7_iasi_metopb_{ymdrr}", "bufr_7_iasi_metopc_{ymdrr}"]
+  local_name = "BUFR.iasi"
+
+[da.providers.UWC.seviri]
+  candidates = ["netcdf_7_seviri_xx_{ymdrr}"]
+  local_name = "NETCDF.seviri"
+
+[da.providers.UWC.synop]
+  candidates = ["obsoul_1_xxxxxx_xx_{ymdrr}"]
+  local_name = "OBSOUL.synop"
+
+[da.providers.UWC.synop_1]
+  candidates = ["obsoul_1_xxxxxy_xx_{ymdrr}"]
+  local_name = "OBSOUL.synop_1"
+
+[da.providers.UWC.temp]
+  candidates = ["obsoul_5_xxxxxx_xx_{ymdrr}"]
+  local_name = "OBSOUL.temp"
+
+[da.providers.UWC.wp]
+  candidates = ["obsoul_6_xxxxxx_xx_{ymdrr}"]
+  local_name = "OBSOUL.wp"
+
+[domain]
+  dtf_lead_time = ""
+  gridtype = "linear"
+  gridtype_oro = ""
+  ilate = 11
+  ilone = 11
+  name = "DKCOEXP"
+  nbzong = -1
+  nbzonl = -1
+  nimax = 637
+  njmax = 637
+  number = ""
+  orographic_smoothing_method = "truncation"
+  tstep = 75
+  xbeta = 0.0
+  xdx = 2500
+  xdy = 2500
+  xlat0 = 56.3
+  xlatcen = 56.3
+  xlon0 = 0.0
+  xloncen = 9.9
+
+[domain.spectral_smoothing_by_gridtype]
+  cubic = false
+  custom = true
+  linear = true
+  quadratic = false
+
+[domain.truncation_by_gridtype]
+  cubic = "cubic"
+  custom = "custom"
+  linear = "quadratic"
+  quadratic = "quadratic"
+
+[eps]
+
+[eps.general]
+  members = [0]
+
+[eps.member_settings]
+
+[eps.member_settings.fdb.grib_set]
+  type = "tactus.eps.custom_generators.FDBTypeGenerator"
+
+[eps.member_settings.general]
+  famodel = "tactus.eps.custom_generators.CmodelGenerator"
+
+[eps.member_settings.namelist_update.master.forecast.namfa]
+  cmodel = "@FAMODEL@"
+
+[eps.member_settings.system]
+  logs = "@ARCHIVE_ROOT@/logs/@MEMBER_STR@"
+  wrk = "@CASEDIR@/@YYYY@@MM@@DD@_@HH@@mm@/@MEMBER_STR@"
+
+[eps.members.0]
+
+[eps.members.0.fdb.grib_set]
+  type = "fc"
+
+[eps.members.0.general]
+  famodel = "@CYCLE@-@CSC@-oper"
+
+[extractsqlite]
+  merged_sqlite_path = "@ARCHIVE_ROOT@/merged_sqlite/FCTABLE/@SQLITE_MODEL_NAME@/@YYYY@/@MM@"
+  parameter_list = []
+  selection = "PT1H"
+  sqlite_model_name = "@CASE@"
+  sqlite_path = "@ARCHIVE_ROOT@/sqlite/FCTABLE/@SQLITE_MODEL_NAME@/@YYYY@/@MM@/@MEMBER_STR@"
+  sqlite_template = "FCTABLE_{PP}_{YYYY}{MM}_{HH}.sqlite"
+
+[[extractsqlite.parameter_list_default_det]]
+  location_file = "@TACTUS_HOME@/data/sqlite/station_list_default.csv"
+  param_file = "@TACTUS_HOME@/data/sqlite/param_list_sfc_@CSC@_det.json"
+
+[[extractsqlite.parameter_list_default_det]]
+  location_file = "@TACTUS_HOME@/data/sqlite/temp_list_default.csv"
+  param_file = "@TACTUS_HOME@/data/sqlite/param_list_ua_det.json"
+
+[[extractsqlite.parameter_list_default_eps]]
+  location_file = "@TACTUS_HOME@/data/sqlite/station_list_default.csv"
+  param_file = "@TACTUS_HOME@/data/sqlite/param_list_sfc_@CSC@_eps.json"
+
+[[extractsqlite.parameter_list_default_eps]]
+  location_file = "@TACTUS_HOME@/data/sqlite/temp_list_default.csv"
+  param_file = "@TACTUS_HOME@/data/sqlite/param_list_ua_eps.json"
+
+[fdb]
+  databridge_user = "@PROD_USER@"
+
+[fdb.grib_set]
+  georef = "u4p033"
+  stream = "oper"
+
+[file_templates]
+
+[file_templates.bdfile]
+  archive = "ICMSH@CNMEXP@+@DURATION_ARCHIVE@"
+
+[file_templates.bdfile_sfx]
+  archive = "ECSFCSFX@DOMAIN@_@BDMEMBER@+@LLL@"
+
+[file_templates.bdfile_sst]
+  archive = "ECSFCSST@DOMAIN@_@BDMEMBER@+@LLL@"
+  model = "ECSFCSST@DOMAIN@_@BDMEMBER@+@NNN@"
+
+[file_templates.ddh_dl]
+  archive = "DHFDL@CNMEXP@+@DURATION_ARCHIVE@"
+  model = "DHFDL@CNMEXP@+@DURATION_MODEL@"
+
+[file_templates.ddh_gl]
+  archive = "DHFGL@CNMEXP@+@DURATION_ARCHIVE@"
+  model = "DHFGL@CNMEXP@+@DURATION_MODEL@"
+
+[file_templates.ddh_zo]
+  archive = "DHFZO@CNMEXP@+@DURATION_ARCHIVE@"
+  model = "DHFZO@CNMEXP@+@DURATION_MODEL@"
+
+[file_templates.duration]
+  archive = "@LLLH@h@LM@m@LS@s"
+  model = "@LLLH@:@LM@:@LS@"
+
+[file_templates.fullpos]
+  archive = "GRIBPF@CNMEXP@+@DURATION_ARCHIVE@"
+  grib = "GRIBPF@CNMEXP@+@DURATION_ARCHIVE@"
+  model = "GRIBPF@CNMEXP@@FPDOMAIN@+@DURATION_MODEL@"
+
+[file_templates.history]
+  archive = "ICMSH@CNMEXP@+@DURATION_ARCHIVE@"
+  grib = "GRIB@CNMEXP@+@DURATION_ARCHIVE@"
+  model = "ICMSH@CNMEXP@+@DURATION_MODEL@"
+
+[file_templates.initfile]
+  archive = "@SCRATCH@/tactus/@PREV_CASE@/archive/@YYYY@/@MM@/@DD@/@HH@/@MEMBER_STR@/@HISTORY_TEMPLATE@"
+
+[file_templates.initfile_sfx]
+  archive = "@SCRATCH@/tactus/@PREV_CASE@/archive/@YYYY@/@MM@/@DD@/@HH@/@MEMBER_STR@/@SURFEX_TEMPLATE@"
+
+[file_templates.interpolated_boundaries]
+  archive = "ELSCF@CNMEXP@ALBC@NNN@"
+  model = "ELSCF@CNMEXP@ALBC@NNN@"
+
+[file_templates.pgd]
+  archive = "Const.Clim@ONE_DECADE@.sfx"
+  model = "Const.Clim.sfx"
+
+[file_templates.pgd_host]
+  archive = "Const.Clim@ONE_DECADE@.sfx"
+  model = "Const.Clim.sfx"
+
+[file_templates.pgd_prel]
+  archive = "PGD_prel@ONE_DECADE@.fa"
+  model = "PGD_prel.fa"
+
+[file_templates.sstfile]
+  archive = "EXT_SST_SIC@NNN@"
+
+[file_templates.surfex]
+  archive = "ICMSH@CNMEXP@+@DURATION_ARCHIVE@.sfx"
+  grib = "GRIB@CNMEXP@+@DURATION_ARCHIVE@.sfx"
+  model = "ICMSH@CNMEXP@+@DURATION_MODEL@.sfx"
+
+[file_templates.tiles]
+  archive = "ICMSH@CNMEXP@+@DURATION_ARCHIVE@.sfx"
+  grib = "GRIBTILE@CNMEXP@+@DURATION_ARCHIVE@.sfx"
+  model = "ICMSH@CNMEXP@+@DURATION_MODEL@.sfx"
+
+[fullpos]
+  config_path = "@CYCLE@/fullpos"
+  domain_name = "DOMAIN"
+  main = ["rules", "namfpc_header"]
+
+[fullpos.selection]
+  master = ["master_selection_@CSC@", "master_subhour_selection_@CSC@", "meteosat"]
+
+[general]
+  accept_static_namelists = false
+  case = "@CASE_PREFIX@@CYCLE@_@CSC@_@DOMAIN@_@YMD_START@"
+  cnmexp = "DEOD"
+  csc = "AROME"
+  cycle = "CY50t2"
+  e923_optional_sections = []
+  famodel = "destine-@CYCLE@-@CSC@-oper"
+  fullpos_windpower = true
+  keep_workdirs = true
+  member = 0
+  member_str = "mbr000"
+  remove_sections = []
+  start_etime = "1779962197.158219"
+  surfex = true
+  surfex_sea_ice = "sice"
+  upd_sst_sic = true
+  windfarm = false
+
+[general.namelist]
+  nrazts = "PT1H"
+  radiation_frequency = "PT5M"
+
+[general.output_settings]
+  fullpos = "PT1H"
+  history = "PT1H"
+  surfex = "PT1H"
+
+[general.times]
+  cycle_length = "PT3H"
+  forecast_range = "PT6H"
+  start = "2025-02-09T00:00:00Z"
+
+[git_info]
+  branch = "bstrajnar_develop_pau"
+  commit = "7fe2f45ed3285b8fff2e4ca132ffc75d50f2f3d1"
+  describe = "7fe2f45e-dirty"
+  remote = "bstrajnar/bstrajnar_develop"
+  remote_url = "git@github.com:bstrajnar/tactus.git"
+
+[gribmodify]
+  conversions = ["fullpos"]
+  gribmodify_rules_file = "@TACTUS_HOME@/data/gribmodify/gribmodify_rules.json"
+
+[gribmodify.fullpos]
+
+[gribmodify.fullpos.1]
+  output_name = "tirf"
+
+[gribmodify.fullpos.2]
+  output_name = "tsnowp"
+
+[gribmodify.fullpos.3]
+  output_name = "10si"
+
+[gribmodify.fullpos.4]
+  output_name = "ws"
+
+[gribmodify.fullpos.5]
+  minimum_frequency = "PT1H"
+  output_name = "max_i10fg"
+
+[gribmodify.fullpos.6]
+  output_name = "2d"
+
+[gribmodify.fullpos.7]
+  output_name = "utci"
+
+[json2tab]
+  config_file = "@TACTUS_HOME@/data/json2tab/json2tab-config.yaml"
+  enabled = true
+  force_rewrite = false
+  loglevel = "auto"
+
+[json2tab.input]
+  turbine_database = [
+    "@WINDFARM_PATH@/turbine_database+gened_ct_curves.json",
+    "@WINDFARM_PATH@/turbine_database+knmi.json",
+    "@WINDFARM_PATH@/turbine_database+wf101.json",
+    "@WINDFARM_PATH@/turbine_specifications+belgian.csv",
+    "@WINDFARM_PATH@/known_wf101_mapping.csv",
+  ]
+  turbine_locations = "@WINDFARM_PATH@/euromap.csv"
+
+[json2tab.output]
+  directory = "@ARCHIVE_ROOT@/windfarm_data/"
+
+[json2tab.output.files]
+  location_tab = "turbine_locations.tab"
+  type_tab_prefix = "wind_turbine_"
+
+[macros]
+
+[macros.case]
+  gen_macros = []
+  group_macros = []
+  os_macros = ["USER"]
+
+[macros.select.default]
+  gen_macros = [
+    "boundaries.bdmodel",
+    "boundaries.bdmodel_sfx",
+    "domain.name",
+    "general.cnmexp",
+    "general.cycle",
+    "general.csc",
+    "general.case",
+    "general.surfex_sea_ice",
+    "domain.orographic_smoothing_method",
+    {bdmember = "boundaries.ifs.bdmember"},
+    {bdfile_template = "file_templates.bdfile.archive"},
+    {case_prefix = "scheduler.ecfvars.case_prefix"},
+    {compiler = "submission.compiler"},
+    {ecf_host_resolved = "scheduler.ecfvars.ecf_host_resolved"},
+    {ecf_port_resolved = "scheduler.ecfvars.ecf_port_resolved"},
+    {domain = "domain.name"},
+    {xdx = "domain.xdx"},
+    {domain_number = "domain.number"},
+    {precision = "submission.precision"},
+    {duration_archive = "file_templates.duration.archive"},
+    {duration_model = "file_templates.duration.model"},
+    {ecf_tactus_home = "scheduler.ecfvars.ecf_tactus_home"},
+    {ecf_files = "scheduler.ecfvars.ecf_files"},
+    {ecf_out = "scheduler.ecfvars.ecf_out"},
+    {famodel = "general.famodel"},
+    {forecast_range = "general.times.forecast_range"},
+    {cycle_length = "general.times.cycle_length"},
+    {fpdomain = "fullpos.domain_name"},
+    {history_template = "file_templates.history.archive"},
+    {mars_selection = "boundaries.ifs.selection"},
+    {pgd_archive = "file_templates.pgd.archive"},
+    {pgd_model = "file_templates.pgd.model"},
+    {member = "general.member"},
+    {members = "eps.general.members"},
+    {member_str = "general.member_str"},
+    {sqlite_path = "extractsqlite.sqlite_path"},
+    {merged_sqlite_path = "extractsqlite.merged_sqlite_path"},
+    {sqlite_model_name = "extractsqlite.sqlite_model_name"},
+    {surfex_template = "file_templates.surfex.archive"},
+    {bindir_gl = "submission.bindir_gl"},
+    {gl_version = "submission.gl_version"},
+    {ial_version = "submission.ial_version"},
+  ]
+  group_macros = ["platform", "system"]
+  os_macros = ["USER", "HOME", "PWD", "CONFIG"]
+
+[mars]
+
+[mars.atos_bologna_DT]
+  default = "RD_DEFAULT"
+  expver = "iekm"
+  ifs_cycle_start = "PT0H"
+  start_date = "2024-07-21T00:00:00Z"
+
+[mars.ATOS_DT]
+  default = "RD_DEFAULT"
+  end_date = "2024-11-11T00:00:00Z"
+  expver = "i4ql"
+  ifs_cycle_start = "PT0H"
+  start_date = "2023-09-09T00:00:00Z"
+
+[mars.ATOS_DT.stream]
+  00 = "OPER"
+
+[mars.DT12]
+  default = "RD_DEFAULT"
+  expver = "i8a8"
+  ifs_cycle_start = "PT12H"
+  start_date = "2023-10-29T00:00:00Z"
+
+[mars.DT12.stream]
+  12 = "OPER"
+
+[mars.HRES]
+  class = "OD"
+  expver = "0001"
+  GG = "32/33/39/40/41/42/139/141/170/172/183/198/235/236/35/36/37/38/238/243/244/245"
+  GG1 = "74/163/160/161/162/15/16/17/18/66/67"
+  GG_lsm = "172"
+  GG_sea = "31/34"
+  GG_skt = "235"
+  GG_snow = "33/238/228038/228141"
+  GG_soil = "234/173/174/43/30/29/28/27"
+  GGZ_type = "analysis"
+  grid_ML = "AV"
+  ifs_cycle_length = "PT6H"
+  ifs_cycle_start = "PT0H"
+  resolution = "9"
+  SH = "152/138/155/130"
+  SHZ = "129"
+  SHZ_type = "AN"
+  SHZdate = "20131129"
+  start_date = "2015-05-13T00:00:00Z"
+  start_snow_date = "2023-06-27T00:00:00Z"
+  type_AN = "AN"
+  type_FC = "FC"
+  UA = "133/75/76/246/247/248"
+  Zlev_type = "ML"
+
+[mars.HRES.grid]
+  "2006-02-01T06:00:00Z" = "0.25/0.25"
+  "2010-01-26T06:00:00Z" = "0.15/0.15"
+  "2016-03-08T00:00:00Z" = "0.09/0.09"
+
+[mars.HRES.grid_GG1]
+  "2006-02-01T06:00:00Z" = "AV"
+  "2016-03-08T00:00:00Z" = "O640"
+
+[mars.HRES.levelist]
+  "2006-02-01T06:00:00Z" = "1/to/91"
+  "2013-06-26T00:00:00Z" = "1/to/137"
+
+[mars.HRES.stream]
+  00 = "OPER"
+  06 = "SCDA"
+  12 = "OPER"
+  18 = "SCDA"
+
+[mars.HRES_CY49t2]
+  default = "HRES"
+  GG = "32/33/39/40/41/42/139/141/170/172/183/198/199/235/236/35/36/37/38/238/243/244/245"
+
+[mars.i5qp]
+  default = "RD_DEFAULT"
+  ifs_cycle_start = "PT0H"
+
+[mars.i5qp.stream]
+  00 = "OPER"
+
+[mars.i7u4]
+  default = "RD_DEFAULT"
+  gg_oro_source = "@STATIC_DATA@/IFS_gridpoint_orography/oro_T3999_F3214"
+  grid = "0.028/0.028"
+  ifs_cycle_start = "PT0H"
+
+[mars.i7u4.stream]
+  00 = "LWDA"
+
+[mars.i7ye]
+  default = "RD_DEFAULT"
+  gg_oro_source = "@STATIC_DATA@/IFS_gridpoint_orography/oro_T3999_F3214"
+  grid = "0.028/0.028"
+  ifs_cycle_start = "PT0H"
+
+[mars.i7ye.stream]
+  00 = "LWDA"
+
+[mars.i8hy]
+  default = "RD_DEFAULT"
+  expver = "i8hy"
+  ifs_cycle_start = "PT0H"
+  start_date = "2017-01-20T00:00:00Z"
+
+[mars.i8hy.stream]
+  00 = "OPER"
+
+[mars.IFSENS]
+  class = "OD"
+  expver = "0001"
+  GG = "32/33/39/40/41/42/139/141/170/172/183/198/235/236/35/36/37/38/238/243/244/245"
+  GG1 = "74/163/160/161/162/66/67"
+  GG_lsm = "172"
+  GG_sea = "31/34"
+  GG_skt = "235"
+  GG_snow = "33/238/228038/228141"
+  GG_soil = "234/173/174/43/30/29/28/27"
+  GGZ_type = "CF"
+  grid_ML = "AV"
+  ifs_cycle_length = "PT6H"
+  ifs_cycle_start = "PT0H"
+  levelist = "1/to/137"
+  resolution = "9"
+  SH = "152/138/155/130"
+  SHZ = "129.128"
+  SHZ_type = "CF"
+  start_date = "1900-01-01T00:00:00Z"
+  start_snow_date = "2023-06-27T00:00:00Z"
+  stream = "ENFO"
+  type_AN = "CF"
+  type_FC = "PF"
+  UA = "133/75/76/246/247/248"
+  Zlev_type = "ML"
+
+[mars.IFSENS.grid]
+  "2023-07-01T00:00:00Z" = "0.09/0.09"
+
+[mars.IFSENS.grid_GG1]
+  "2006-02-01T06:00:00Z" = "AV"
+  "2016-03-08T00:00:00Z" = "O640"
+
+[mars.iit7]
+  default = "RD_DEFAULT"
+  end_date = "2024-07-09T00:00:00Z"
+  expver = "iit7"
+  GGZ_type = "CF"
+  ifs_cycle_start = "PT0H"
+  SHZ_type = "CF"
+  start_date = "2024-07-09T00:00:00Z"
+  stream = "ENFO"
+  type_AN = "CF"
+  type_FC = "PF"
+
+[mars.ilv7]
+  default = "RD_DEFAULT"
+  end_date = "2021-08-17T00:00:00Z"
+  expver = "ilv7"
+  GGZ_type = "CF"
+  ifs_cycle_length = "PT12H"
+  ifs_cycle_start = "PT12H"
+  SHZ_type = "CF"
+  start_date = "2021-08-16T12:00:00Z"
+  stream = "ENFO"
+  type_AN = "CF"
+  type_FC = "PF"
+
+[mars.irok]
+  default = "RD_DEFAULT"
+  end_date = "2022-05-03T00:00:00Z"
+  expver = "irok"
+  GGZ_type = "CF"
+  ifs_cycle_length = "PT12H"
+  SHZ_type = "CF"
+  start_date = "2022-05-02T00:00:00Z"
+  stream = "ENFO"
+  type_AN = "CF"
+  type_FC = "PF"
+
+[mars.is6g]
+  default = "RD_DEFAULT"
+  end_date = "2022-05-03T00:00:00Z"
+  expver = "is6g"
+  GGZ_type = "CF"
+  grid = "0.09/0.09"
+  ifs_cycle_length = "PT12H"
+  resolution = "9"
+  SHZ_type = "CF"
+  start_date = "2022-05-02T00:00:00Z"
+  stream = "ENFO"
+  type_AN = "CF"
+  type_FC = "PF"
+
+[mars.iyzp]
+  default = "RD_DEFAULT"
+  end_date = "2023-08-20T00:00:00Z"
+  expver = "iyzp"
+  start_date = "2023-08-20T00:00:00Z"
+
+[mars.lumi_DT]
+  class = "D1"
+  default = "RD_DEFAULT"
+  expver = "0001"
+  GG_snow = "33/238"
+  GGZ_type = "AN"
+  ifs_cycle_start = "PT0H"
+  SH = "152/138/155"
+  sh_oro_source = "/projappl/project_465000527/models/ifs/static-data/rdx/data/climate/climate.v020/2559_4/sporog"
+  SH_temperature = "130"
+  SHZ_type = "AN"
+  SHZclass = "OD"
+  SHZdate = "20131129"
+  start_date = "2024-04-06T00:00:00Z"
+  use_static_sh = true
+  Zlev_type = "SFC"
+
+[mars.obs]
+  class = "OD"
+  expver = "0001"
+  obstype = "LSD/SSD/SLNS/VSNS"
+  range = "180"
+  repres = "BUFR"
+  start_date = "1900-07-09T00:00:00Z"
+  stream = "OPER"
+  type_OB = "OB"
+
+[mars.RD_DEFAULT]
+  class = "RD"
+  GG = "32/33/39/40/41/42/139/141/170/172/183/198/235/236/35/36/37/38/238/243/244/245"
+  GG_lsm = "172"
+  gg_oro_source = "@STATIC_DATA@/IFS_gridpoint_orography/oro_T2559_F2250"
+  GG_sea = "31/34"
+  GG_skt = "235"
+  GG_snow = "33/238/228038/228141"
+  GGZ_type = "FC"
+  grid = "0.04/0.04"
+  grid_ML = "AV"
+  ifs_cycle_length = "PT24H"
+  ifs_cycle_start = "PT0H"
+  levelist = "1/to/137"
+  resolution = "4"
+  SH = "152/138/155/130"
+  SHZ = "129"
+  SHZ_type = "FC"
+  SHZdate = "20131129"
+  start_date = "1900-01-01T00:00:00Z"
+  stream = "OPER"
+  type_AN = "AN"
+  type_FC = "FC"
+  UA = "133/75/76/246/247/248"
+  use_static_gg = true
+  Zlev_type = "ML"
+
+[pgd]
+  npatch = 3
+  one_decade = true
+  use_osm = false
+
+[platform]
+  albnir_soil_dir = "@CLIMDATA@/ECOCLIMAP-SG/ALB_SAT"
+  albnir_veg_dir = "@CLIMDATA@/ECOCLIMAP-SG/ALB_SAT"
+  albvis_soil_dir = "@CLIMDATA@/ECOCLIMAP-SG/ALB_SAT"
+  albvis_veg_dir = "@CLIMDATA@/ECOCLIMAP-SG/ALB_SAT"
+  archive_root = "@SCRATCH@/tactus/@CASE@/archive"
+  archive_types = ["compress", "copy", "ecfs", "fdb"]
+  climdata = "@STATIC_DATA@/climate"
+  e923_data = "@STATIC_DATA@/climate/E923_DATA"
+  eclipse_data_dir = "@STATIC_DATA@/climate/eclipse"
+  ecoclim_data_path = "@CLIMDATA@/ecoclimap"
+  ecoclimap_bin_dir = "@ecoclim_data_path@"
+  ecosg_data_path = "@CLIMDATA@/ECOCLIMAP-SG"
+  fixed_bddir = "/scratch/sism/DEOL/@YYYY@/@MM@/@DD@/@HH@"
+  flake_dir = "@STATIC_DATA@/climate/PGD"
+  global_sfcdir = "@STATIC_DATA@/climate_fields_mir/climate.v020_MIR_orog/@RESOLUTION@km/@MM@"
+  host = "atos_bologna"
+  install_dir = "/perm/deployde330/github-actions/install/"
+  lai_dir = "@CLIMDATA@/ECOCLIMAP-SG/LAI_SAT"
+  ncdir = "@STATIC_DATA@/ncdir"
+  osm_data_eu = "@CLIMDATA@/OSM_SFX8_1_EU/GARDEN/"
+  pgd_data_path = "@CLIMDATA@/PGD"
+  reference_data = "@SCRATCH@/tactus"
+  references_folder = "@SCRATCH@/tactus_references"
+  references_generation_folder = "@SCRATCH@/tactus_generated_references"
+  rrtm_dir = "@STATIC_DATA@/rrtm/@CYCLE@"
+  rttov_coefdir = "@STATIC_DATA@/satellite/rtcoef_rttov13/coef/"
+  scratch = "/scratch/@USER@"
+  soilgrid_data_path = "@CLIMDATA@/SOILGRID"
+  static_data = "/hpcperm/snh02/DEODE"
+  tactus_fdb_home = "/home/fdbtest"
+  tactus_home = "set-by-the-system"
+  task_name = "@STAND_ALONE_TASK_NAME@"
+  topo_data_path = "@CLIMDATA@/GMTED2010"
+  topo_source = "gmted2010"
+  tree_height_dir = "@CLIMDATA@/ECOCLIMAP-SG/HT"
+  unix_group = "accord"
+  uv_cache_dir = "/perm/@USER@/.cache/uv"
+  windfarm_path = "@STATIC_DATA@/WFP_input_files/"
+
+[reference_checker]
+  analyze_summary = ["ReferenceCheck"]
+  check = false
+  create_summary = ["PrepRun"]
+  generate = false
+  label_suffix = "@MEMBER_STR@"
+  rules_active = ["Forecast.fullpos", "Forecast.history", "Forecast.log"]
+  summary_active = ["txt", "json"]
+  suppress_exception = false
+
+[reference_checker.methods]
+  mode = "get_worst"
+  which = "first_and_last_spectral"
+
+[reference_checker.methods.ForecastNorms]
+  mode = "get_worst"
+  tolerance = "12"
+  tool = "norms_checker"
+  which = "first_and_last_spectral"
+
+[reference_checker.methods.FullPosFields]
+  args_template = "-f1 {test_file} -f2 {reference_file} {file_format} -s -of SCREEN -de -to {tolerance}"
+  binary = "@INSTALL_DIR@/gl/@COMPILER@/latest/bin/xtool"
+  file_format = "GRIB"
+  tolerance = "10"
+  tool = "xtool"
+
+[reference_checker.methods.HistoryFields]
+  args_template = "-f1 {test_file} -f2 {reference_file} {file_format} -s -of SCREEN -de -to {tolerance}"
+  binary = "@INSTALL_DIR@/gl/@COMPILER@/latest/bin/xtool"
+  file_format = "FA"
+  tolerance = "10"
+  tool = "xtool"
+
+[reference_checker.summary]
+  file = "@WRK@/checks/summary.txt"
+  format = "txt"
+
+[reference_checker.summary.json]
+  file = "@CASEDIR@/checks/summary.json"
+  format = "json"
+
+[reference_checker.summary.txt]
+  file = "@CASEDIR@/checks/summary.txt"
+  format = "txt"
+
+[reference_checker.task.Forecast]
+
+[reference_checker.task.Forecast.fullpos]
+  generate_folder = "@REFERENCES_GENERATION_FOLDER@/@CASE@/@ARCHIVE_TIMESTAMP@/@MEMBER_STR@"
+  inpath = "@ARCHIVE@"
+  method = "FullPosFields"
+  pattern = "GRIBPF.*0006h00m00s"
+  reference_folder = "@REFERENCES_FOLDER@/@CASE@/@ARCHIVE_TIMESTAMP@/@MEMBER_STR@"
+  result_folder = "@WRK@/checks/Forecast"
+
+[reference_checker.task.Forecast.history]
+  generate_folder = "@REFERENCES_GENERATION_FOLDER@/@CASE@/@ARCHIVE_TIMESTAMP@/@MEMBER_STR@"
+  inpath = "@ARCHIVE@"
+  method = "HistoryFields"
+  pattern = "ICMSH.*0006h00m00s"
+  reference_folder = "@REFERENCES_FOLDER@/@CASE@/@ARCHIVE_TIMESTAMP@/@MEMBER_STR@"
+  result_folder = "@WRK@/checks/Forecast"
+
+[reference_checker.task.Forecast.log]
+  generate_folder = "@REFERENCES_GENERATION_FOLDER@/@CASE@/@ARCHIVE_TIMESTAMP@/@MEMBER_STR@"
+  inpath = "@WRK@/logs/Forecast"
+  method = "ForecastNorms"
+  pattern = "NODE.001_01"
+  reference_folder = "@REFERENCES_FOLDER@/@CASE@/@ARCHIVE_TIMESTAMP@/@MEMBER_STR@"
+  result_folder = "@WRK@/checks/Forecast"
+
+[remove]
+
+[remove.defaults]
+  active = true
+  dry_run = true
+  execute_removal = false
+  ncycles_delay = 0
+  path = ""
+  wipe = true
+
+[remove.main]
+  remove_from_scheduler = true
+  remove_not_completed_suites = false
+  suite_name = "@CASE@"
+
+[remove.main.ecfs]
+  ecfs_prefix = "@ARCHIVING.PREFIX.ECFS@"
+  path = ""
+
+[remove.main.ifs]
+  active = false
+  path = "@REFERENCE_DATA@/IFS"
+
+[remove.main.zz_case_dir]
+  path = "@CASEDIR@"
+
+[scheduler]
+
+[scheduler.ecfvars]
+  case_prefix = ""
+  ecf_files = "@HOME@/tactus_ecflow/ecf_files"
+  ecf_files_remotely = "@HOME@/tactus_ecflow/ecf_files"
+  ecf_home = "@HOME@/tactus_ecflow/jobout"
+  ecf_host = "_select_host_from_list(['ecfg-@USER@-1', 'ecflow-gen-@USER@-001'],)"
+  ecf_host_resolved = ""
+  ecf_jobout = "@HOME@/tactus_ecflow/jobout"
+  ecf_out = "@HOME@/tactus_ecflow/jobout"
+  ecf_port = 3141
+  ecf_port_resolved = ""
+  ecf_remoteuser = ""
+  ecf_ssl = "0"
+  ecf_tactus_home = "strip_off_mount_path('@TACTUS_HOME@',)"
+  ecf_tries = 1
+  ecf_user = ""
+
+[scheduler.ecfvars.troika]
+  config_file = "@ECF_TACTUS_HOME@/data/config_files/troika.yml"
+
+[scheduler.mirror_host_case]
+  check_var = ""
+  mirror_name = "host_case"
+  remote_auth = ""
+  remote_host = "_select_host_from_list(['ecfg-@USER@-1', 'ecflow-gen-@USER@-001'],)"
+  remote_path = "/@HOST_CASE@/@YYYY@@MM@@DD@/@HH@@mm@/mbr000/Cycle/Forecasting"
+  remote_polling = "300"
+  remote_port = "3141"
+  remote_ssl = false
+
+[submission]
+  bindir = "/perm/sis/tactus_bin/@CYCLE@/@COMPILER@/@PRECISION@/bin"
+  bindir_gl = "@INSTALL_DIR@/gl/@COMPILER@/@GL_VERSION@/bin/"
+  compiler = "intel"
+  default_submit_type = "serial"
+  gl_version = "latest"
+  ial_version = "latest"
+  lfftw = true
+  module_initpath = "/usr/local/apps/lmod/8.6.8/init"
+  nproma = -32
+  precision = "R64"
+
+[submission.iomerge]
+
+[submission.iomerge.age_limit]
+  forecast_directory = 300
+  fullpos = 15
+  history = 20
+  surfex = 15
+
+[submission.iomerge.files_expected]
+  fullpos = 0
+  history = -1
+  surfex = 0
+
+[submission.task]
+  wrapper = ""
+
+[submission.task_exceptions]
+
+[submission.task_exceptions.AddCalculatedFields.MODULES]
+  ECMWFTOOLBOX = ["load", "ecmwf-toolbox/2026.01.0.0"]
+
+[submission.task_exceptions.ArchiveFDB]
+
+[submission.task_exceptions.ArchiveFDB.ENV]
+  FDB5_HOME = "/home/fdbtest/versions/7.30.6.0/"
+  FDB_ENABLE_GRIBJUMP = "1"
+  FDB_HOME = "@TACTUS_FDB_HOME@"
+  GRIBJUMP_CONFIG_FILE = "@TACTUS_FDB_HOME@/etc/gribjump/config_on-demand-extremes-dt.yaml"
+
+[submission.task_exceptions.ArchiveFDB.MODULES]
+  ECMWFTOOLBOX = ["load", "ecmwf-toolbox/2026.01.0.0"]
+
+[submission.task_exceptions.ArchiveHour.BATCH]
+  WALLTIME = "#SBATCH --time=03:00:00"
+
+[submission.task_exceptions.ArchiveStatic.BATCH]
+  WALLTIME = "#SBATCH --time=03:00:00"
+
+[submission.task_exceptions.Bator]
+  bindir = "/perm/sis/tactus_bin/@CYCLE@/@COMPILER@/@PRECISION@/bin_gmkpack"
+  NPROC = 1
+
+[submission.task_exceptions.Bator.BATCH]
+  NTASKS = "#SBATCH --ntasks=1"
+  WALLTIME = "#SBATCH --time=00:10:00"
+
+[submission.task_exceptions.Bator.ENV]
+  DR_HOOK_ASSERT_MPI_INITIALIZED = "0"
+
+[submission.task_exceptions.Bator.MODULES]
+  01_INTEL = ["load", "intel/2023.2.0"]
+
+[submission.task_exceptions.BlendSur]
+  binary = "BLENDSUR"
+  bindir = "/perm/sis/tactus_bin/@CYCLE@/@COMPILER@/@PRECISION@/bin_gmkpack"
+  NPROC = 1
+
+[submission.task_exceptions.BlendSur.BATCH]
+  NTASKS = "#SBATCH --ntasks=1"
+  WALLTIME = "#SBATCH --time=00:10:00"
+
+[submission.task_exceptions.BlendSur.MODULES]
+  01_INTEL = ["load", "intel/2023.2.0"]
+
+[submission.task_exceptions.C903]
+  NPROC = 36
+  OMP_NUM_THREADS = "4"
+
+[submission.task_exceptions.C903.BATCH]
+  CPUSPERTASK = "#SBATCH --cpus-per-task=4"
+  HYPERTHREAD = "#SBATCH --hint=nomultithread"
+  MEM_CPU = "#SCATCH --mem-per-cpu=50G"
+  NODES = "#SBATCH --nodes=18"
+  NTASKS = "#SBATCH --ntasks-per-node=2"
+  WALLTIME = "#SBATCH --time=01:00:00"
+
+[submission.task_exceptions.C903.ENV]
+  KMP_AFFINITY = "granularity=core,scatter"
+  KMP_BLOCKTIME = "12"
+  OMP_STACKSIZE = "4G"
+
+[submission.task_exceptions.Canari]
+  bindir = "/perm/sis/tactus_bin/@CYCLE@/@COMPILER@/@PRECISION@/bin_gmkpack"
+  NPROC = 16
+
+[submission.task_exceptions.Canari.BATCH]
+  MEM = "#SBATCH --mem=16000MB"
+  NODES = "#SBATCH --nodes=1"
+  NTASKS = "#SBATCH --ntasks=16"
+  WALLTIME = "#SBATCH --time=00:30:00"
+
+[submission.task_exceptions.Canari.MODULES]
+  01_INTEL = ["load", "intel/2023.2.0"]
+  OPENMPI = ["load", "openmpi/4.1.1.1"]
+
+[submission.task_exceptions.CreateGrib]
+  binary = "gl"
+  bindir = "@BINDIR_GL@"
+
+[submission.task_exceptions.CreateGrib.BATCH]
+  WALLTIME = "#SBATCH --time=01:00:00"
+
+[submission.task_exceptions.CreateGribStatic]
+  bindir = "@BINDIR_GL@"
+
+[submission.task_exceptions.E927]
+  NPROC = 16
+
+[submission.task_exceptions.E927.BATCH]
+  NODES = "#SBATCH --nodes=1"
+  NTASKS = "#SBATCH --ntasks=16"
+
+[submission.task_exceptions.ExtractSQlite]
+  ECMWFTOOLBOX = ["load", "ecmwf-toolbox/2026.01.0.0"]
+
+[submission.task_exceptions.Forecast]
+  bindir = "@INSTALL_DIR@/@CYCLE@/@COMPILER@/@PRECISION@/@IAL_VERSION@/bin"
+  NPROC = 30
+  NPROC_IO = 2
+
+[submission.task_exceptions.Forecast.BATCH]
+  NODES = "#SBATCH --nodes=2"
+  NTASKS = "#SBATCH --ntasks=32"
+  WALLTIME = "#SBATCH --time=01:00:00"
+
+[submission.task_exceptions.Forecast.ENV]
+  RTTOV_COEFDIR = "@RTTOV_COEFDIR@"
+  UCX_LOG_LEVEL = "error"
+
+[submission.task_exceptions.GlBd]
+  binary = "gl"
+  bindir = "/perm/deployde330/github-actions/install/gl/latest/bin"
+
+[submission.task_exceptions.IALBundleBuild.BATCH]
+  MEM = "#SBATCH --mem=0GB"
+  NODES = "#SBATCH --nodes=1"
+  NTASKS = "#SBATCH --ntasks=32"
+  WALLTIME = "#SBATCH --time=02:00:00"
+
+[submission.task_exceptions.InterpolSstSic]
+  binary = "gl"
+  bindir = "@BINDIR_GL@"
+
+[submission.task_exceptions.IOmerge.BATCH]
+  WALLTIME = "#SBATCH --time=01:00:00"
+
+[submission.task_exceptions.Marsobs]
+  bindir = "/usr/local/bin/"
+
+[submission.task_exceptions.Marsobs.BATCH]
+  MEM = "#SBATCH --mem=128GB"
+  NODES = "#SBATCH --nodes=1"
+  NTASKS = "#SBATCH --ntasks=1"
+  QOS = "#SBATCH --qos=np"
+  WALLTIME = "#SBATCH --time=06:00:00"
+
+[submission.task_exceptions.Marsobs.ENV]
+  MARS_MULTITARGET_STRICT_FORMAT = 1
+  MARS_READANY_BUFFER_SIZE = 17893020000
+
+[submission.task_exceptions.Marsprep]
+  bindir = "/usr/local/bin/"
+
+[submission.task_exceptions.Marsprep.BATCH]
+  MEM = "#SBATCH --mem=128GB"
+  NODES = "#SBATCH --nodes=1"
+  NTASKS = "#SBATCH --ntasks=1"
+  QOS = "#SBATCH --qos=np"
+  WALLTIME = "#SBATCH --time=06:00:00"
+
+[submission.task_exceptions.Marsprep.ENV]
+  MARS_MULTITARGET_STRICT_FORMAT = 1
+  MARS_READANY_BUFFER_SIZE = 17893020000
+
+[submission.task_exceptions.Minim]
+  bindir = "@INSTALL_DIR@/@CYCLE@/@COMPILER@/@PRECISION@/@IAL_VERSION@/bin"
+  NPROC = 128
+
+[submission.task_exceptions.Minim.BATCH]
+  CPUSPERTASK = "#SBATCH --cpus-per-task=8"
+  NODES = "#SBATCH --nodes=16"
+  NTASKS = "#SBATCH --ntasks-per-node=16"
+  WALLTIME = "#SBATCH --time=00:45:00"
+
+[submission.task_exceptions.Minim.ENV]
+  OMP_NUM_THREADS = "8"
+  OMP_PLACES = "threads"
+
+[submission.task_exceptions.ObsPrep]
+  NPROC = 1
+
+[submission.task_exceptions.ObsPrep.BATCH]
+  NTASKS = "#SBATCH --ntasks=1"
+  WALLTIME = "#SBATCH --time=00:20:00"
+
+[submission.task_exceptions.OdbMerge]
+  bindir = "/perm/sis/tactus_bin/@CYCLE@/@COMPILER@/@PRECISION@/bin_gmkpack"
+  NPROC = 1
+
+[submission.task_exceptions.OdbMerge.BATCH]
+  NTASKS = "#SBATCH --ntasks=1"
+  WALLTIME = "#SBATCH --time=00:15:00"
+
+[submission.task_exceptions.OdbMerge.MODULES]
+  01_INTEL = ["load", "intel/2023.2.0"]
+
+[submission.task_exceptions.OopsVar]
+  bindir = "/perm/sis/tactus_bin/@CYCLE@/@COMPILER@/@PRECISION@/bin_gmkpack"
+  NPROC = 128
+
+[submission.task_exceptions.OopsVar.BATCH]
+  HINT = "#SBATCH --hint=nomultithread"
+  NODES = "#SBATCH --nodes=10"
+  NTASKS = "#SBATCH --ntasks=128"
+  WALLTIME = "#SBATCH --time=01:00:00"
+
+[submission.task_exceptions.OopsVar.MODULES]
+  01_INTEL = ["load", "intel/2023.2.0"]
+  MPIPACKAGE1 = ["unload", "hpcx-openmpi/2.9.0"]
+  MPIPACKAGE2 = ["load", "openmpi/4.1.1.1"]
+
+[submission.task_exceptions.Pgd]
+  NPROC = 2
+  WRAPPER = "srun -n @NPROC@"
+
+[submission.task_exceptions.Pgd.BATCH]
+  NODES = "#SBATCH --nodes=1"
+  NTASKS = "#SBATCH --ntasks=2"
+  WALLTIME = "#SBATCH --time=00:30:00"
+
+[submission.task_exceptions.PgdUpdate]
+  binary = "gl"
+  bindir = "@BINDIR_GL@"
+
+[submission.task_exceptions.Prep]
+  WRAPPER = "srun -n @NPROC@"
+
+[submission.task_exceptions.Prep.BATCH]
+  NODES = "#SBATCH --nodes=1"
+  NTASKS = "#SBATCH --ntasks=1"
+  WALLTIME = "#SBATCH --time=00:10:00"
+
+[submission.task_exceptions.Screen]
+  bindir = "@INSTALL_DIR@/@CYCLE@/@COMPILER@/@PRECISION@/@IAL_VERSION@/bin"
+  NPROC = 128
+
+[submission.task_exceptions.Screen.BATCH]
+  CPUSPERTASK = "#SBATCH --cpus-per-task=2"
+  MEM = "#SBATCH --mem=200GB"
+  NODES = "#SBATCH --nodes=6"
+  NTASKS = "#SBATCH --ntasks=128"
+  WALLTIME = "#SBATCH --time=00:30:00"
+
+[submission.task_exceptions.Screen.ENV]
+  OMP_NUM_THREADS = "2"
+  OMP_PLACES = "threads"
+
+[submission.task_exceptions.Soil.MODULES]
+  GDAL = ["load", "gdal/3.6.2"]
+
+[submission.task_exceptions.Topography.MODULES]
+  GDAL = ["load", "gdal/3.6.2"]
+
+[submission.types]
+
+[submission.types.background_hpc]
+  NPROC_IO = 0
+  SCHOST = "localhost"
+  tasks = ["Background_hpc", "UnitTest"]
+  WRAPPER = ""
+
+[submission.types.background_vm]
+  INTERPRETER = "#!/usr/bin/python3"
+  NPROC_IO = 0
+  SCHOST = "localhost"
+  tasks = ["Background_vm"]
+  WRAPPER = ""
+
+[submission.types.GMKPACK_EXECUTABLES]
+  NPROC = 1
+  NPROC_IO = 0
+  NPROCX = 1
+  NPROCY = 1
+  SCHOST = "hpc"
+  tasks = [
+    "Bator_synop",
+    "Bator_gpssol",
+    "Bator_amdr",
+    "Bator_geowind",
+    "Bator_temp",
+    "Bator_wp",
+    "Bator_seviri",
+    "Bator_amsua",
+    "Bator_amsub",
+    "Bator_iasi",
+    "Bator_ascat",
+    "OdbMerge",
+  ]
+  WRAPPER = "srun"
+
+[submission.types.GMKPACK_EXECUTABLES.BATCH]
+  NAME = "#SBATCH --job-name=@TASK_NAME@"
+  NODES = "#SBATCH --nodes=1"
+  NTASKS = "#SBATCH --ntasks=1"
+  QOS = "#SBATCH --qos=nf"
+  WALLSIGNAL = "#SBATCH --signal=USR1@30"
+  WALLTIME = "#SBATCH --time=00:15:00"
+
+[submission.types.GMKPACK_EXECUTABLES.ENV]
+  DR_HOOK_IGNORE_SIGNALS = -1
+  OMP_NUM_THREADS = 1
+  OMPI_MCA_btl = "^vader"
+
+[submission.types.GMKPACK_EXECUTABLES.MODULES]
+  00_PRGENV = ["load", "prgenv/intel"]
+  01_INTEL = ["load", "intel/2023.2.0"]
+  ECMWFTOOLBOX = ["load", "ecmwf-toolbox/2026.01.0.0"]
+  FFTW = ["load", "fftw/3.3.10"]
+  HDF5 = ["load", "hdf5/1.14.6"]
+  MKL = ["load", "intel-mkl/19.0.5"]
+  NETCDF = ["load", "netcdf4/4.9.3"]
+  OPENMPI = ["load", "openmpi/4.1.1.1"]
+
+[submission.types.gnu]
+  NPROC = 1
+  NPROC_IO = 0
+  NPROCX = 1
+  NPROCY = 1
+  SCHOST = "hpc"
+  tasks = ["ExtractSQLite"]
+  WRAPPER = "srun"
+
+[submission.types.gnu.BATCH]
+  NAME = "#SBATCH --job-name=@TASK_NAME@"
+  NODES = "#SBATCH --nodes=1"
+  NTASKS = "#SBATCH --ntasks=1"
+  QOS = "#SBATCH --qos=nf"
+  WALLSIGNAL = "#SBATCH --signal=USR1@30"
+  WALLTIME = "#SBATCH --time=00:15:00"
+
+[submission.types.parallel]
+  NPROC = 32
+  NPROC_IO = 0
+  SCHOST = "hpc"
+  tasks = ["Forecast", "E927", "Pgd", "Prep", "C903", "IALBundleBuild"]
+  WRAPPER = "srun"
+
+[submission.types.parallel.BATCH]
+  NAME = "#SBATCH --job-name=@TASK_NAME@"
+  QOS = "#SBATCH --qos=np"
+  WALLSIGNAL = "#SBATCH --signal=USR1@30"
+  WALLTIME = "#SBATCH --time=00:10:00"
+
+[submission.types.parallel.ENV]
+  DR_HOOK = 1
+  DR_HOOK_IGNORE_SIGNALS = -1
+  OMP_NUM_THREADS = 1
+  OMPI_MCA_btl = "^vader"
+
+[submission.types.parallel.MODULES]
+  00_PRGENV = ["load", "prgenv/intel"]
+  ECMWFTOOLBOX = ["load", "ecmwf-toolbox/2026.01.0.0"]
+  FFTW = ["load", "fftw/3.3.10"]
+  HDF5 = ["load", "hdf5/1.14.6"]
+  MKL = ["load", "intel-mkl/19.0.5"]
+  NETCDF = ["load", "netcdf4/4.9.3"]
+  OPENMPI = ["load", "hpcx-openmpi/2.9.0"]
+
+[submission.types.serial]
+  NPROC = 1
+  NPROC_IO = 0
+  NPROCX = 1
+  NPROCY = 1
+  SCHOST = "hpc"
+  tasks = [
+    "CreateGrib",
+    "Topography",
+    "Soil",
+    "Marsprep",
+    "Marsobs",
+    "E923Update",
+    "IOmerge",
+    "InterpolSstSic",
+    "GenerateWfpTabFile",
+  ]
+  WRAPPER = "srun"
+
+[submission.types.serial.BATCH]
+  NAME = "#SBATCH --job-name=@TASK_NAME@"
+  NODES = "#SBATCH --nodes=1"
+  NTASKS = "#SBATCH --ntasks=1"
+  QOS = "#SBATCH --qos=nf"
+  WALLSIGNAL = "#SBATCH --signal=USR1@30"
+  WALLTIME = "#SBATCH --time=00:15:00"
+
+[submission.types.serial.ENV]
+  DR_HOOK_IGNORE_SIGNALS = -1
+  OMP_NUM_THREADS = 1
+  OMPI_MCA_btl = "^vader"
+
+[submission.types.serial.MODULES]
+  00_PRGENV = ["load", "prgenv/intel"]
+  ECMWFTOOLBOX = ["load", "ecmwf-toolbox/2026.01.0.0"]
+  FFTW = ["load", "fftw/3.3.10"]
+  HDF5 = ["load", "hdf5/1.14.6"]
+  MKL = ["load", "intel-mkl/19.0.5"]
+  NETCDF = ["load", "netcdf4/4.9.3"]
+  OPENMPI = ["load", "hpcx-openmpi/2.9.0"]
+
+[suite_control]
+  compile = false
+  create_static_data = true
+  create_time_dependent_suite = true
+  do_archiving = true
+  do_assimilation = true
+  do_cleaning = true
+  do_creategrib_static = false
+  do_extractsqlite = true
+  do_interpolsstsic = true
+  do_marsobs = true
+  do_marsprep = true
+  do_mergesqlite = true
+  do_pgd = true
+  do_soil = true
+  interpolate_boundaries = true
+  max_static_data_tasks = 10
+  member_specific_mars_prep = false
+  member_specific_static_data = false
+  mirror_globalDT = false
+  mirror_host_case = false
+  mirror_offline = false
+  mode = "cold_start"
+  n_addcalculatedfields = 2
+  n_creategrib = 2
+  n_io_merge = 0
+  split_mars = false
+  suite_definition = "TactusSuiteDefinition"
+
+[system]
+  archive = "@ARCHIVE_ROOT@/@ARCHIVE_TIMESTAMP@/@MEMBER_STR@"
+  archive_timestamp = "@YYYY@/@MM@/@DD@/@HH@/"
+  assimilation_input_definition = "@CYCLE@/assimilation.json"
+  bdclimdir = "@FIXED_BDCLIMDIR@"
+  bddir = "@REFERENCE_DATA@/IFS/@MARS_SELECTION@/@YYYY@/@MM@/@DD@/@HH@"
+  bddir_sfx = "@BDDIR@"
+  bddir_sst = "@BDDIR@"
+  c903_input_definition = "@CYCLE@/c903.json"
+  casedir = "@SCRATCH@/tactus/@CASE@"
+  climdir = "@CASEDIR@/climate/@DOMAIN@"
+  e923_input_definition = "@CYCLE@/e923.json"
+  e927_input_definition = "@CYCLE@/e927.json"
+  forecast_dir_link = "../Forecast"
+  forecast_input_definition = "@CYCLE@/forecast.json"
+  intp_bddir = "@WRK@"
+  intp_bddir_sfx = "@ARCHIVE@"
+  logs = "@ARCHIVE_ROOT@/logs"
+  namelists = "@TACTUS_HOME@/data/namelists/@CYCLE@"
+  prev_case = "@CASE@"
+  sfx_input_definition = "@CYCLE@/sfx.json"
+  wrk = "@CASEDIR@/@YYYY@@MM@@DD@_@HH@@mm@"
+
+[troika]
+  config_file = "@TACTUS_HOME@/data/config_files/troika.yml"
+  troika = "troika"
+
+[vertical_levels]
+  ahalf = [
+    0.0,
+    2718.281829,
+    3747.089291,
+    4915.58716,
+    6184.629456,
+    7511.826567,
+    8869.101344,
+    10030.304356,
+    10981.652856,
+    11785.441359,
+    12467.115388,
+    13036.9966,
+    13504.534974,
+    13878.638942,
+    14167.467732,
+    14378.164793,
+    14516.624747,
+    14587.358345,
+    14595.755313,
+    14546.696521,
+    14444.613314,
+    14293.673022,
+    14097.987345,
+    13861.830406,
+    13589.853257,
+    13287.281608,
+    12960.083871,
+    12612.25171,
+    12247.287675,
+    11868.24584,
+    11477.7789,
+    11078.188746,
+    10671.478183,
+    10259.401904,
+    9843.515363,
+    9425.220462,
+    9005.8073,
+    8586.491397,
+    8168.695589,
+    7753.760647,
+    7342.954609,
+    6937.48058,
+    6538.483021,
+    6147.052425,
+    5764.228347,
+    5391.000788,
+    5028.309984,
+    4677.04468,
+    4338.03901,
+    4012.068233,
+    3699.843282,
+    3402.004748,
+    3119.007629,
+    2851.141239,
+    2598.537627,
+    2361.182186,
+    2138.926037,
+    1931.499783,
+    1738.528216,
+    1559.545611,
+    1394.01124,
+    1241.32489,
+    1100.841912,
+    971.887912,
+    853.7727,
+    746.106511,
+    648.446293,
+    560.305239,
+    481.162282,
+    410.471379,
+    347.670445,
+    292.189811,
+    243.460098,
+    200.919421,
+    164.01988,
+    132.23327,
+    105.05605,
+    82.013496,
+    62.744832,
+    46.885714,
+    34.071514,
+    23.940739,
+    16.138537,
+    10.320302,
+    6.155336,
+    3.330576,
+    1.554347,
+    0.56013,
+    0.110328,
+    0.0,
+    0.0,
+  ]
+  bhalf = [
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0020808742,
+    0.0063342307,
+    0.0121732181,
+    0.0193986154,
+    0.0278371306,
+    0.0373529653,
+    0.047842939,
+    0.0592352126,
+    0.0714873482,
+    0.0845746582,
+    0.0983741718,
+    0.1128383503,
+    0.1279315334,
+    0.14361854,
+    0.1598595007,
+    0.1766044735,
+    0.1937879788,
+    0.2113235966,
+    0.2290987842,
+    0.2469701004,
+    0.2649022016,
+    0.2828675957,
+    0.3008456607,
+    0.3188216081,
+    0.3367854211,
+    0.3547307961,
+    0.372654106,
+    0.3905533994,
+    0.4084274461,
+    0.4262748343,
+    0.4440931265,
+    0.4618674416,
+    0.4795830255,
+    0.49722498,
+    0.5147780123,
+    0.5322262004,
+    0.5495527773,
+    0.5667399335,
+    0.5837686388,
+    0.6006184839,
+    0.6172675404,
+    0.6336922407,
+    0.6498672716,
+    0.6657654933,
+    0.6813578657,
+    0.696619345,
+    0.711528319,
+    0.7260667007,
+    0.7402199922,
+    0.7539773233,
+    0.7673314668,
+    0.780278834,
+    0.7928194542,
+    0.804956941,
+    0.8166984434,
+    0.8280546004,
+    0.839039477,
+    0.849670505,
+    0.8599386316,
+    0.869836944,
+    0.8793606592,
+    0.8885071083,
+    0.8972757162,
+    0.9056679778,
+    0.9136874321,
+    0.9213396338,
+    0.9286321259,
+    0.9355744104,
+    0.9421779224,
+    0.948455999,
+    0.9544238611,
+    0.960072977,
+    0.9653949126,
+    0.9703813221,
+    0.9750239392,
+    0.9793145669,
+    0.9832450676,
+    0.9868073535,
+    0.9899933762,
+    0.9927951169,
+    0.9952045769,
+    0.9972137692,
+    0.9988147073,
+    1.0,
+  ]
+  nlev = 90

--- a/tactus/data/config_files/config.toml
+++ b/tactus/data/config_files/config.toml
@@ -122,6 +122,7 @@
   do_extractsqlite = true
   do_interpolsstsic = true
   do_marsprep = true
+  do_marsobs = true
   do_mergesqlite = true
   do_pgd = true
   do_soil = true

--- a/tactus/data/config_files/config_file_schemas/submission_section_schema.json
+++ b/tactus/data/config_files/config_file_schemas/submission_section_schema.json
@@ -97,6 +97,29 @@
               "default": {}
             }
           }
+        },
+	"Marsobs": {
+          "type": "object",
+          "description": "Settings specific to Marsobs tasks",
+          "properties": {
+            "ENV": {
+              "type": "object",
+              "description": "Sets environment variables",
+              "properties": {
+                "MARS_MULTITARGET_STRICT_FORMAT": {
+                  "type": "number",
+                  "description": "Strict format for multitarget operations",
+                  "default": 1
+                },
+                "MARS_READANY_BUFFER_SIZE": {
+                  "type": "number",
+                  "description": "Reandomly buffer size in mars",
+                  "default": 17893020000
+                }
+              },
+              "default": {}
+            }
+          }
         }
       }
     },

--- a/tactus/data/config_files/include/domains/DKCOEXP.toml
+++ b/tactus/data/config_files/include/domains/DKCOEXP.toml
@@ -1,0 +1,12 @@
+[domain]
+  gridtype = "linear"
+  name = "DKCOEXP"
+  nimax = 637 
+  njmax = 637 
+  tstep = 75
+  xdx = 2500
+  xdy = 2500
+  xlatcen = 56.3
+  xloncen = 9.9
+  xlat0 = 56.3
+  xlon0 = 0.0

--- a/tactus/data/config_files/include/mars_settings.toml
+++ b/tactus/data/config_files/include/mars_settings.toml
@@ -227,3 +227,13 @@
   UA = "133/75/76/246/247/248"
   use_static_gg = true
   Zlev_type = "ML"
+
+[mars.obs]
+  expver = "0001"
+  class = "OD"
+  stream = "OPER"
+  repres = "BUFR"
+  type_OB = "OB"
+  start_date = "1900-07-09T00:00:00Z"
+  range = "180"
+  obstype = "LSD/SSD/SLNS/VSNS"

--- a/tactus/data/config_files/include/submission/atos_bologna.toml
+++ b/tactus/data/config_files/include/submission/atos_bologna.toml
@@ -106,7 +106,17 @@
 [submission.task_exceptions.Marsprep]
   bindir = "/usr/local/bin/"
 
+[submission.task_exceptions.Marsobs]
+  bindir = "/usr/local/bin/"
+
 [submission.task_exceptions.Marsprep.BATCH]
+  MEM = "#SBATCH --mem=128GB"
+  NODES = "#SBATCH --nodes=1"
+  NTASKS = "#SBATCH --ntasks=1"
+  QOS = "#SBATCH --qos=np"
+  WALLTIME = "#SBATCH --time=06:00:00"
+
+[submission.task_exceptions.Marsobs.BATCH]
   MEM = "#SBATCH --mem=128GB"
   NODES = "#SBATCH --nodes=1"
   NTASKS = "#SBATCH --ntasks=1"
@@ -204,6 +214,7 @@
     "Topography",
     "Soil",
     "Marsprep",
+    "Marsobs",
     "E923Update",
     "IOmerge",
     "InterpolSstSic",

--- a/tactus/data/config_files/modifications/assimilation.toml
+++ b/tactus/data/config_files/modifications/assimilation.toml
@@ -1,0 +1,427 @@
+# Data assimilation modification file
+# ------------------------------------------------------------------
+# Enables the CANARI (surface OI) + 3D-Var upper-air assimilation
+# chain between FirstGuess and Forecast.
+#
+# Usage:
+#   tactus case @<config_file> assimilation.toml -o <output.toml> --start-suite
+#
+# Required: fill in [da] paths below for your site / experiment.
+# ------------------------------------------------------------------
+
+# submission
+[submission]
+bindir = "/perm/sis/tactus_bin/@CYCLE@/@COMPILER@/@PRECISION@/bin"
+precision = "R64"
+
+[system]
+assimilation_input_definition = "@CYCLE@/assimilation.json"
+
+[suite_control]
+  do_assimilation = true
+
+# ------------------------------------------------------------------
+# DA section — paths and tuning
+# ------------------------------------------------------------------
+[da]
+  # Root directory for pre-processed observation files (OPLACE / local)
+  # Expected layout: <obs_dir>/YYYY/MM/DD/<obstype_filename>[.gz]
+  obs_dir = "@SCRATCH@/da/@CASE@/obs"
+
+  # Per-cycle scratch store for intermediate DA files (ODB, CCMA, analyses)
+  scratch = "@SCRATCH@/da/@CASE@/scratch"
+
+  # Directory containing DA constants:
+  #   B-matrix (stabal96.cv/bal), error files (errgrib*),
+  #   RTTOV coefficients, blacklists (LISTE_NOIRE_DIAP, LISTE_LOC), etc.
+  const_dir = "@SCRATCH@/da/const"
+
+  # Directory containing DA namelists:
+  #   aldnml_canari, aldnml_screen, aldnml_minim,
+  #   aldnml_bator, aldnml_lamflag_<domain>, aldnml_rgb, etc.
+  namelist_dir = "@SCRATCH@/da/namelists"
+
+  # Short-range background (first-guess) directory.
+  # Expected files: <guess_dir>/YYYY/MM/DD/guess.YYYYMMDDRR[.gz]
+  guess_dir = "@SCRATCH@/da/@CASE@/guess"
+
+  # Archive directory for final DA analysis fields.
+  # Forecast uses: <analysis_dir>/YYYY/MM/DD/analysis.YYYYMMDDRR
+  analysis_dir = "@SCRATCH@/da/@CASE@/analysis"
+
+  # Variational bias correction (VARBC) archive.
+  # Expected: <varbc_dir>/YYYY/MM/DD/VARBC.cycle_<RR>
+  varbc_dir = "@SCRATCH@/da/@CASE@/varbc"
+
+  # RTTOV satellite channel coefficient files (inherited from platform if set)
+  rttov_coef_dir = "@RTTOV_COEFDIR@"
+
+  # Number of ODB pools used by BATOR / SHUFFLE
+  nbpool = 16
+
+  # Cold-start basetime (YYYYMMDDRR): skips VARBC / first-guess checks.
+  # Set to the first cycle of a new experiment.
+  bgcycle = ""
+
+  # Enable OpenMP threading in MASTERODB screening step
+  openmp = true
+
+  # Observation types for CANARI surface analysis (obsprep + BATOR)
+  obs_types_surface = ["synop"]
+
+  # Observation types for 3D-Var upper-air analysis
+  obs_types_3dvar = [
+    "synop", "gpssol",
+    "amdr", "geowind", "temp", "wp",
+    "seviri", "amsua", "amsub", "iasi", "ascat",
+  ]
+
+  # ------------------------------------------------------------------
+  # Active observation network  ← the only line a user needs to change
+  # ------------------------------------------------------------------
+  # Names the [da.providers.<name>] block that ObsPrep will use to locate
+  # observation files.  All network conventions are defined below in the
+  # [da.providers.*] registry; no code changes are needed to switch or to
+  # add a new network.
+  obs_provider = "LACE"
+
+# ------------------------------------------------------------------
+# BATOR window / slot configuration
+# ------------------------------------------------------------------
+  bator_window_len   = 180   # window length [minutes], symmetric around analysis time
+  bator_window_shift = -90   # window start offset [minutes] (negative = before)
+  bator_slot_len     = 0     # slot length [minutes]; 0 = single slot
+  bator_nbslot       = 1     # number of BATOR time slots
+
+  # Path to the obsoul_merge.pl script used to merge multiple OBSOUL files.
+  # Supports @CYCLE@, @COMPILER@, @PRECISION@ substitutions.
+  obsoul_merge_script = "/perm/sis/tactus_bin/@CYCLE@/@COMPILER@/@PRECISION@/bin/obsoul_merge.pl"
+
+# ------------------------------------------------------------------
+# GPS station whitelist for BATOR (list_gpssol)
+# ------------------------------------------------------------------
+  gpssol_stations = []
+
+# ==================================================================
+# Observation network registry
+# ==================================================================
+# Each [da.providers.<NAME>] block defines one observation provider.
+# ObsPrep reads the block selected by da.obs_provider at runtime.
+#
+# Network-level settings:
+#   obs_step  — minutes between archive file slots.
+#               0 = single slot at basetime (windowing disabled).
+#               60 = hourly archive; all slots inside the assimilation
+#                    window are searched and results merged.
+#
+# Per-obstype sub-tables ([da.providers.<NAME>.<obstype>]):
+#   candidates  — filename templates tried in order.  All matches
+#                 across all window slots are collected and merged.
+#                 Placeholders: {ymdrr}, {yyyy}, {mm}, {dd}, {rr}.
+#   local_name  — filename BATOR expects in the working directory.
+#   source_dir  — optional; overrides da.obs_dir/YYYY/MM/DD as the
+#                 search root (supports @PLATFORM@ substitutions).
+# ==================================================================
+
+# ------------------------------------------------------------------
+# LACE — Central-European limited-area consortium convention.
+# Conventional obs in per-country OBSOUL files; satellite in BUFR/NETCDF.
+# Files are stored as hourly chunks; obs_step=60 collects the full window.
+# ------------------------------------------------------------------
+[da.providers.LACE]
+obs_step = 60
+
+[da.providers.LACE.synop]
+
+candidates = [
+  "obsoul_1_xxxxxx_hu_{ymdrr}",
+  "obsoul_1_xxxxxy_hu_{ymdrr}",
+  "obsoul_1_xxxxxy_at_{ymdrr}",
+  "obsoul_1_xxxxxy_cz_{ymdrr}",
+  "obsoul_1_xxxxxy_sk_{ymdrr}",
+  "obsoul_1_xxxxxy_ro_{ymdrr}",
+  "obsoul_1_xxxxxy_si_{ymdrr}",
+  "obsoul_1_xxxxxy_cr_{ymdrr}",
+  "obsoul_1_xxxxxy_pl_{ymdrr}",
+]
+local_name = "OBSOUL.synop"
+obs_step = 0
+
+[da.providers.LACE.gpssol]
+candidates = ["bufr_1_ztd_egvap_{ymdrr}"]
+local_name  = "BUFR.gpssol"
+
+[da.providers.LACE.amdr]
+candidates = ["obsoul_2_xxxxxx_xx_{ymdrr}", "obsoul_2_ehs_eu_{ymdrr}"]
+local_name  = "OBSOUL.amdr"
+
+[da.providers.LACE.geowind]
+candidates = ["bufr_3_geowind_xx_{ymdrr}"]
+local_name  = "BUFR.geowind"
+
+[da.providers.LACE.temp]
+candidates = ["obsoul_5_xxxxxx_xx_{ymdrr}"]
+local_name  = "OBSOUL.temp"
+
+[da.providers.LACE.wp]
+candidates = ["obsoul_6_xxxxxx_xx_{ymdrr}"]
+local_name  = "OBSOUL.wp"
+
+[da.providers.LACE.amsua]
+candidates = [
+  "bufr_7_amsua_metopc_{ymdrr}",
+  "bufr_7_amsua_metopb_{ymdrr}",
+  "bufr_7_amsua_noaa18_{ymdrr}",
+  "bufr_7_amsua_noaa19_{ymdrr}",
+]
+local_name = "BUFR.amsua"
+
+[da.providers.LACE.amsub]
+candidates = [
+  "bufr_7_mhs_metopc_{ymdrr}",
+  "bufr_7_mhs_metopb_{ymdrr}",
+  "bufr_7_mhs_noaa19_{ymdrr}",
+]
+local_name = "BUFR.amsub"
+
+[da.providers.LACE.seviri]
+candidates = ["netcdf_7_seviri_xx_{ymdrr}"]
+local_name  = "NETCDF.seviri"
+obs_step    = 0
+
+[da.providers.LACE.iasi]
+candidates = [
+  "bufr_7_iasi_metopb_{ymdrr}",
+  "bufr_7_iasi_metopc_{ymdrr}",
+]
+local_name = "BUFR.iasi"
+
+[da.providers.LACE.ascat]
+candidates = [
+  "bufr_9_ascatC_metopb_{ymdrr}",
+  "bufr_9_ascatC_metopc_{ymdrr}",
+]
+local_name = "BUFR.ascat"
+
+# ------------------------------------------------------------------
+# UWC — United Weather Centres / ECMWF OPLACE convention.
+# Conventional obs as obsoul_<code>_xxxxxx_xx_<YYYYMMDDRR>;
+# satellite obs as BUFR_<YYYYMMDDRR>.<type> or NETCDF_*.
+# ------------------------------------------------------------------
+[da.providers.UWC]
+obs_step = 60
+
+[da.providers.UWC.synop]
+candidates = ["obsoul_1_xxxxxx_xx_{ymdrr}"]
+local_name  = "OBSOUL.synop"
+
+[da.providers.UWC.synop_1]
+candidates = ["obsoul_1_xxxxxy_xx_{ymdrr}"]
+local_name  = "OBSOUL.synop_1"
+
+[da.providers.UWC.amdr]
+candidates = ["obsoul_2_xxxxxx_xx_{ymdrr}"]
+local_name  = "OBSOUL.amdr"
+
+[da.providers.UWC.geowind]
+candidates = ["obsoul_3_xxxxxx_xx_{ymdrr}"]
+local_name  = "OBSOUL.geowind"
+
+[da.providers.UWC.temp]
+candidates = ["obsoul_5_xxxxxx_xx_{ymdrr}"]
+local_name  = "OBSOUL.temp"
+
+[da.providers.UWC.wp]
+candidates = ["obsoul_6_xxxxxx_xx_{ymdrr}"]
+local_name  = "OBSOUL.wp"
+
+[da.providers.UWC.gpssol]
+candidates = ["obsoul_9_xxxxxx_xx_{ymdrr}"]
+local_name  = "OBSOUL.gpssol"
+
+[da.providers.UWC.amsua]
+candidates = [
+  "bufr_7_amsua_metopc_{ymdrr}",
+  "bufr_7_amsua_metopb_{ymdrr}",
+  "bufr_7_amsua_noaa18_{ymdrr}",
+  "bufr_7_amsua_noaa19_{ymdrr}",
+]
+local_name = "BUFR.amsua"
+
+[da.providers.UWC.amsub]
+candidates = [
+  "bufr_7_mhs_metopc_{ymdrr}",
+  "bufr_7_mhs_metopb_{ymdrr}",
+  "bufr_7_mhs_noaa19_{ymdrr}",
+]
+local_name = "BUFR.amsub"
+
+[da.providers.UWC.seviri]
+candidates = ["netcdf_7_seviri_xx_{ymdrr}"]
+local_name  = "NETCDF.seviri"
+
+[da.providers.UWC.iasi]
+candidates = [
+  "bufr_7_iasi_metopb_{ymdrr}",
+  "bufr_7_iasi_metopc_{ymdrr}",
+]
+local_name = "BUFR.iasi"
+
+[da.providers.UWC.ascat]
+candidates = [
+  "bufr_9_ascatC_metopb_{ymdrr}",
+  "bufr_9_ascatC_metopc_{ymdrr}",
+]
+local_name = "BUFR.ascat"
+
+# ------------------------------------------------------------------
+# MF — Météo-France BDAP convention.
+# Fill in correct filenames for your BDAP access point.
+# ------------------------------------------------------------------
+[da.providers.MF]
+obs_step = 60
+
+# Add MF or other provider's observation description 
+
+# ------------------------------------------------------------------
+# Submission settings for DA tasks
+# ------------------------------------------------------------------
+
+[submission.task_exceptions.ObsPrep]
+  NPROC = 1
+
+[submission.task_exceptions.ObsPrep.BATCH]
+  NTASKS   = "#SBATCH --ntasks=1"
+  WALLTIME = "#SBATCH --time=00:20:00"
+
+# ---- BATOR (one task per obs type, serial per type) ----
+# BATOR is NOT yet built by the IAL CMake pipeline (which only produces MASTERODB).
+# It comes from a separate ARPEGE/ALADIN ODB compilation.
+# Point to the directory that contains BATOR, BLENDSUR,
+# shuffle, create_ioassign, ioassign, and merge_ioassign.
+[submission.task_exceptions.Bator]
+  bindir = "/perm/sis/tactus_bin/@CYCLE@/@COMPILER@/@PRECISION@/bin_gmkpack"
+  NPROC  = 1
+
+[submission.task_exceptions.Bator.BATCH]
+  NTASKS   = "#SBATCH --ntasks=1"
+  WALLTIME = "#SBATCH --time=00:10:00"
+
+[submission.task_exceptions.Bator.MODULES]
+  01_INTEL = ["load", "intel/2023.2.0"]
+
+[submission.task_exceptions.Bator.ENV]
+  DR_HOOK_ASSERT_MPI_INITIALIZED = "0"
+
+# ---- OdbMerge (shuffle + merge_ioassign) ----
+[submission.task_exceptions.OdbMerge]
+  bindir = "/perm/sis/tactus_bin/@CYCLE@/@COMPILER@/@PRECISION@/bin_gmkpack"  
+  NPROC  = 1
+
+[submission.task_exceptions.OdbMerge.BATCH]
+  NTASKS   = "#SBATCH --ntasks=1"
+  WALLTIME = "#SBATCH --time=00:15:00"
+
+[submission.task_exceptions.OdbMerge.MODULES]
+  01_INTEL = ["load", "intel/2023.2.0"]
+
+# ---- Canari (MASTERODB conf 701, surface OI) ----
+[submission.task_exceptions.Canari]
+  bindir = "/perm/sis/tactus_bin/@CYCLE@/@COMPILER@/@PRECISION@/bin_gmkpack"
+  NPROC  = 16
+
+[submission.task_exceptions.Canari.BATCH]
+  NODES    = "#SBATCH --nodes=1"
+  NTASKS   = "#SBATCH --ntasks=16"
+  WALLTIME = "#SBATCH --time=00:30:00"
+  MEM = "#SBATCH --mem=16000MB"
+
+[submission.task_exceptions.Canari.MODULES]
+  01_INTEL = ["load", "intel/2023.2.0"]
+  OPENMPI = ["load", "openmpi/4.1.1.1"]
+
+
+
+
+# ---- BlendSur (serial BLENDSUR utility) ----
+[submission.task_exceptions.BlendSur]
+  bindir = "/perm/sis/tactus_bin/@CYCLE@/@COMPILER@/@PRECISION@/bin_gmkpack"
+  binary = "BLENDSUR"
+  NPROC  = 1
+
+[submission.task_exceptions.BlendSur.BATCH]
+  NTASKS   = "#SBATCH --ntasks=1"
+  WALLTIME = "#SBATCH --time=00:10:00"
+
+[submission.task_exceptions.BlendSur.MODULES]
+  01_INTEL = ["load", "intel/2023.2.0"]
+
+# ------------------------------------------------------------------
+# Surface-only DA mode
+# ------------------------------------------------------------------
+# By default both surface OI (CANARI) and upper-air 3D-Var (OOVAR) are run.
+# Set da.do_upper_air = false to run the surface chain only (CANARI +
+# BlendSur) without the UpperAir family.  Useful for refining the CANARI
+# chain independently or for surface-analysis-only experiments.
+#
+# do_upper_air = false
+
+# ------------------------------------------------------------------
+# OOPS-based 3D-Var (upper-air analysis via OOVAR)
+# ------------------------------------------------------------------
+
+ [da.oops]
+   namelist_dir = "@SCRATCH@/da/oops_namelists"
+#
+#   # Minimization inner-loop settings
+#   niter    = 66
+#   nsimu    = 69
+#   rednmc   = 0.5
+#
+
+# ---- OopsVar (OOPS-based 3D-Var, single OOVAR call) ----
+[submission.task_exceptions.OopsVar]
+  bindir = "/perm/sis/tactus_bin/@CYCLE@/@COMPILER@/@PRECISION@/bin_gmkpack"
+  NPROC  = 128
+
+[submission.task_exceptions.OopsVar.BATCH]
+  NODES       = "#SBATCH --nodes=10"
+  NTASKS      = "#SBATCH --ntasks=128"
+  HINT        = "#SBATCH --hint=nomultithread"
+  WALLTIME    = "#SBATCH --time=01:00:00"
+
+[submission.task_exceptions.OopsVar.MODULES]
+  01_INTEL = ["load", "intel/2023.2.0"]
+  MPIPACKAGE1 = ["unload", "hpcx-openmpi/2.9.0"]
+  MPIPACKAGE2 = ["load", "openmpi/4.1.1.1"]
+
+# ---- Screen (MASTERODB observational screening, OpenMP) ----
+[submission.task_exceptions.Screen]
+  bindir = "@INSTALL_DIR@/@CYCLE@/@COMPILER@/@PRECISION@/@IAL_VERSION@/bin"
+  NPROC  = 128
+
+[submission.task_exceptions.Screen.BATCH]
+  NODES       = "#SBATCH --nodes=6"
+  NTASKS      = "#SBATCH --ntasks=128"
+  CPUSPERTASK = "#SBATCH --cpus-per-task=2"
+  MEM         = "#SBATCH --mem=200GB"
+  WALLTIME    = "#SBATCH --time=00:30:00"
+
+[submission.task_exceptions.Screen.ENV]
+  OMP_NUM_THREADS = "2"
+  OMP_PLACES      = "threads"
+
+# ---- Minim (MASTERODB 3D-Var minimization, OpenMP) ----
+[submission.task_exceptions.Minim]
+  bindir = "@INSTALL_DIR@/@CYCLE@/@COMPILER@/@PRECISION@/@IAL_VERSION@/bin"
+  NPROC  = 128
+
+[submission.task_exceptions.Minim.BATCH]
+  NODES       = "#SBATCH --nodes=16"
+  NTASKS      = "#SBATCH --ntasks-per-node=16"
+  CPUSPERTASK = "#SBATCH --cpus-per-task=8"
+  WALLTIME    = "#SBATCH --time=00:45:00"
+
+[submission.task_exceptions.Minim.ENV]
+  OMP_NUM_THREADS = "8"
+  OMP_PLACES      = "threads"

--- a/tactus/mars_utils.py
+++ b/tactus/mars_utils.py
@@ -618,6 +618,9 @@ class BaseRequest:
         target (str): Target file or identifier for the output.
         request (dict): A dictionary representation of the request, initialized
             automatically upon object creation.
+        range (str): time range in minutes for the obs window
+        repres (str): format of observations
+        obstype (str list): observation types
     """
 
     class_: str
@@ -630,6 +633,9 @@ class BaseRequest:
     param: str
     target: str
     request: dict = field(init=False)
+    range: str
+    repres: str
+    obstype: List[str]
 
     def __post_init__(self):
         self.request = {
@@ -639,9 +645,12 @@ class BaseRequest:
             "LEVTYPE": self.levtype,
             "DATE": self.date,
             "TIME": self.time,
-            "STEP": "/".join(map(str, self.steps)),
+            "STEP": "/".join(map(str, self.steps or [] )),
             "PARAM": self.param,
             "TARGET": self.target,
+            "RANGE": self.range,
+            "REPRES": self.repres,
+            "OBSTYPE": self.obstype,
         }
 
     def update_request(self, upd: dict):

--- a/tactus/suites/tactus_suite_components.py
+++ b/tactus/suites/tactus_suite_components.py
@@ -620,6 +620,7 @@ class InputDataFamily(EcflowSuiteFamily):
         trigger=None,
         ecf_files_remotely=None,
         external_marsprep_trigger_node=None,
+        external_marsobs_trigger_node=None,
         add_var_trigger=None,
         remote_path=None,
         member=0,
@@ -696,6 +697,27 @@ class InputDataFamily(EcflowSuiteFamily):
                         ecf_files_remotely=ecf_files_remotely,
                     )
 
+        marsobs_trigger_nodes = [prepare_cycle]
+
+        if external_marsobs_trigger_node is not None:
+            marsobs_trigger_nodes.extend(external_marsobs_trigger_node)
+
+        if (
+            config["suite_control.do_marsobs"]
+            #and not config["suite_control.split_mars"]
+        ):
+            EcflowSuiteTask(
+                "Marsobs",
+                self,
+                config,
+                task_settings,
+                ecf_files,
+                input_template=input_template,
+                trigger=marsobs_trigger_nodes,
+                ecf_files_remotely=ecf_files_remotely,
+                add_var_trigger=add_var_trigger,
+                remote_path=remote_path,
+            )
 
 class PrepFamily(EcflowSuiteFamily):
     """Class for creating the PrepFamily ecFlow family."""

--- a/tactus/tasks/marsobs.py
+++ b/tactus/tasks/marsobs.py
@@ -1,0 +1,1237 @@
+"""Marsobs."""
+
+import ast
+import contextlib
+import os
+import shutil
+from functools import cached_property
+from pathlib import Path, PurePosixPath
+from typing import Dict, List, Optional
+from datetime import timedelta
+
+from tactus.boundary_utils import Boundary
+from tactus.datetime_utils import as_datetime, as_timedelta
+from tactus.eps.eps_setup import get_member_config, infer_members
+from tactus.logs import logger
+from tactus.mars_utils import (
+    BaseRequest,
+    add_additional_data_to_all,
+    add_additional_file_specific_data,
+    check_data_available,
+    compile_target,
+    fix_snow_layer,
+    get_and_remove_data,
+    get_domain_data,
+    get_mars_keys,
+    get_steplist,
+    get_steps_and_members_to_retrieve,
+    get_value_from_dict,
+    mars_selection,
+    mars_write_method,
+    move_files,
+    wait4_file,
+    waitfor_files,
+    write_compute_mars_req,
+    write_retrieve_mars_req,
+    write_write_mars_req,
+)
+from tactus.os_utils import join_files, list_files_join, tactusmakedirs
+from tactus.scheduler import EcflowServer
+from tactus.tasks.base import Task
+from tactus.tasks.batch import BatchJob
+
+
+class Marsobs(Task):
+    """Marsprep task."""
+
+    def __init__(self, config):
+        """Construct forecast object.
+
+        Args:
+            config (tactus.ParsedConfig): Configuration
+
+        Raises:
+            ValueError: No data for this date.
+        """
+        Task.__init__(self, config, __class__.__name__)
+
+        # Get observations from MARS
+
+        ## Get bdmember(s) from member specific eps setting if member specific
+        ## mars prep is enabled
+        #if self.config["suite_control.member_specific_mars_prep"]:
+        #    try:
+        #        member_ = int(os.environ.get("MEMBER"))
+        #    except ValueError as exc:
+        #        raise ValueError(
+        #            "MEMBER environment variable must be an integer if "
+        #            "suite_control.member_specific_mars_prep is True"
+        #        ) from exc
+        #    else:
+        #        member_config = get_member_config(self.config, member_)
+        #        bdmember_config_value = member_config["boundaries.ifs.bdmember"]
+        #
+        ## Get bdmember(s) from eps members settings (attempted first) or
+        ## boundaries.ifs.bdmember.
+        #else:
+        #    try:
+        #        bdmember_config_value = self.config[
+        #            "eps.member_settings.boundaries.ifs.bdmember"
+        #        ]
+        #    except KeyError:
+        #        bdmember_config_value = self.config["boundaries.ifs.bdmember"]
+        #
+        #self.bdmember = infer_members(self.platform.substitute(bdmember_config_value))
+        # Default to [None] if self.bdmember is empty to cover the deterministic
+        # case with no boundary member nesting.
+        #if not self.bdmember:
+        #    self.bdmember = [None]
+
+        # path to sfcdata on disk
+        #resolution = self.mars["resolution"]
+        #self.platform.store_macro("RESOLUTION", resolution)
+        #self.sfcdir = Path(
+        #    self.platform.substitute(
+        #        str(self.platform.get_platform_value("global_sfcdir"))
+        #    )
+        #)
+
+        #logger.info(f"sfc dir: {self.sfcdir}")
+        # Get the MARS config for observations
+        self.mars = mars_selection("obs", self.config)
+
+        # Get the times from config.toml
+        self.basetime = as_datetime(self.config["general.times.basetime"])
+        #forecast_range = as_timedelta(self.config["general.times.forecast_range"])
+
+        # Check if there are data for specific date in mars
+        check_data_available(self.basetime, self.mars)
+
+        # Get boundary informations
+        #self.boundary = Boundary(config)
+        #self.steps = get_steplist(
+        #    self.boundary.bd_offset, forecast_range, self.boundary.bdint
+        #)
+
+        init_dtg = self.basetime - as_timedelta(timedelta(minutes=int(int(self.mars["range"])*0.5)))
+        self.init_date_str = init_dtg.strftime("%Y%m%d") 
+        self.init_hour_str = init_dtg.strftime("%H%M")
+
+        '''
+        exist_snow = False
+        with contextlib.suppress(KeyError):
+            self.param_snow = get_value_from_dict(
+                self.mars["GG_snow"], self.init_date_str
+            )
+            exist_snow = True
+
+        start_snow_date = as_datetime(self.mars["start_date"])
+        with contextlib.suppress(KeyError):
+            start_snow_date = as_datetime(self.mars["start_snow_date"])
+
+        self.exist_snow = exist_snow and self.boundary.bd_basetime >= start_snow_date
+        # Split mars by bdint
+        self.split_mars = self.config["suite_control.split_mars"]
+        if self.split_mars:
+            self.prep_step = ast.literal_eval(self.config["task.args.prep_step"])
+        '''
+
+        # prepdir should be obsdir
+        self.obsdir = Path(
+            self.platform.substitute(
+                self.config["da.obs_dir"],
+                validtime=self.basetime,
+            )
+        )
+        logger.info("MARS data expected in:{}", self.obsdir)
+
+        self.mars_version = int(
+            self.config.get("submission.task_exceptions.Marsprep.mars_version", "6")
+        )
+
+        self.mars_bin = self.get_binary("mars")
+
+        # Use fixed static orography files (spherical harmonics and/or gaussian grid)
+        # TODO: check existence of static orography files & read settings
+        if "use_static_sh" in self.mars:
+            self.use_static_sh_oro = bool(self.mars["use_static_sh"])
+        else:
+            self.use_static_sh_oro = False
+        if self.use_static_sh_oro:
+            self.sh_oro_source = self.mars["sh_oro_source"]
+            logger.info("Using static SH orography file {}", self.sh_oro_source)
+
+        if "use_static_gg" in self.mars:
+            self.use_static_gg_oro = bool(self.mars["use_static_gg"])
+        else:
+            self.use_static_gg_oro = False
+        if self.use_static_gg_oro:
+            self.gg_oro_source = self.mars["gg_oro_source"]
+            logger.info("Using static GG orography file {}", self.gg_oro_source)
+
+    @cached_property
+    def mars(self) -> dict:
+        """Get mars selection."""
+        selection = self.platform.substitute(self.config["boundaries.ifs.selection"])
+        return mars_selection(selection, self.config)
+
+    def update_data_request(
+        self,
+        request: BaseRequest,
+        prefetch: bool,
+        specify_domain: bool,
+        bdmember: Optional[List[int]] = None,
+        grid: Optional[str] = None,
+        source: Optional[str] = None,
+        fieldset: Optional[str] = None,
+        obsretrieve: Optional[bool] = False,
+    ):
+        """Create ECMWF MARS system request.
+
+        Args:
+            request:            BaseRequest object to update
+            prefetch:           Retrieve or stage
+            specify_domain:     Use lat/lon and rotation or use global (default)
+            bdmember:          Boundary members to retrieve in case of eps.
+            grid:               Specific grid for some request. Default None.
+            source:             Sorce for retrieve data from disk. Defaults None.
+            fieldset:           Name of fieldset. Defaults None.
+
+        """
+        if grid is not None and self.mars_version == 6:
+            request.update_request({"GRID": grid})
+
+        # Additional request parameters if EPS
+        # Only if all members are True like. This makes it possible to distinguish
+        # between a deterministic run with no boundary member nesting (members = [None])
+        # and an ensemble run with boundary member nesting (e.g. members = [0]
+        # for a one member ensemble, members = [0, 1, 2] for a three member ensemble etc.)
+        if bdmember and all(bdmember):
+            request.update_request({"NUMBER": "/".join(map(str, bdmember))})
+
+        if self.mars_version == 6:
+            request.update_request({"PROCESS": "LOCAL"})
+        # In obs retrieve we don't use LEVELIST...
+        if not obsretrieve:
+            request.add_levelist(self.mars["levelist"])
+
+        if request.param == "32":
+            request.update_request({"LEVELIST": "1"})
+
+        # Set stream
+        stream = get_value_from_dict(self.mars["stream"], request.time)
+        request.update_request({"STREAM": stream})
+
+        # Retrieve from already fetched data
+        if not prefetch:
+            request.update_request({"SOURCE": source})
+            # NOTE: the following could be moved to get_geopotential_latlon()
+            if "mars_latlonZ" in request.target and (
+                self.use_static_gg_oro or self.use_static_sh_oro
+            ):
+                z_keys = get_mars_keys(source)
+                request.update_request(z_keys)
+
+        request.add_database_options()
+
+        if specify_domain:
+            # In obs retrieve we don't use GRID...
+            if not obsretrieve:
+                request.update_request({
+                   "GRID": get_value_from_dict(self.mars["grid"], request.date),
+                   "AREA": get_domain_data(self.config),
+                })
+            else:
+                request.update_request({
+                   "AREA": get_domain_data(self.config),
+                })
+                   
+        if fieldset:
+            request.update_request({"FIELDSET": fieldset})
+
+        # In obs retrieve we don't use STEP, PARAM ans LEVTYPE
+        if obsretrieve:
+            request.request.pop("STEP", None)
+            request.request.pop("PARAM", None)
+            request.request.pop("LEVTYPE", None)
+
+    def execute(self):
+        """Run task.
+
+        Define run sequence.
+
+        Raises:
+            RuntimeError: If there is an issue with the work folder.
+        """
+        try:
+            if not os.path.exists(self.obsdir):
+                tactusmakedirs(
+                    self.obsdir,
+                    unixgroup=self.platform.get_platform_value("unix_group"),
+                )
+        except OSError as e:
+            raise RuntimeError(f"Error while preparing the mars folder: {e}") from e
+
+        # Suspend the model task if there is a mirroring
+        if self.config["suite_control.mirror_globalDT"]:
+            current_path = PurePosixPath(os.environ["ECF_NAME"])
+            model_path = current_path.parents[1] / "Mirrors"
+            server = EcflowServer(self.config)
+            server.suspend(str(model_path))
+
+        #if self.split_mars and self.prep_step:
+        #    logger.debug("*** Need only latlon data")
+        #else:
+            #if self.split_mars:
+            #    self.steps = [self.steps[int(self.config["task.args.bd_index"])]]
+            #
+            #logger.info("Need steps:{}", self.steps)
+            #self.get_grid_point_surface_data()
+            #self.get_spectral_harmonic_data()
+            #self.get_grid_point_upper_air_data()
+            #
+            #if self.config["suite_control.do_interpolsstsic"]:
+            #    self.get_sst_data()
+        self.get_observations("test")
+
+        #if not self.config["boundaries.bd_has_surfex"]:
+        #    self.get_sfx_data()
+
+    def get_grid_point_surface_data(self):
+        """Get grid point surface data."""
+        tag = "ICMGG"
+        steps, waitfor_steps, members_dict, _, _ = get_steps_and_members_to_retrieve(
+            self.steps,
+            self.prepdir,
+            tag,
+            self.bdmember,
+            platform=self.platform,
+            use_lockfile=self.config["boundaries.do_slaf"],
+        )
+        if steps:
+            self.get_gg_data(tag, steps, members_dict)
+            if "CY50" in self.config["general.cycle"]:
+                fix_snow_layer(tag, steps, members_dict)
+            exist_soil = False
+            with contextlib.suppress(KeyError):
+                gg_soil_param = get_value_from_dict(
+                    self.mars["GG_soil"], self.init_date_str
+                )
+                gg1_param = get_value_from_dict(self.mars["GG1"], self.init_date_str)
+                exist_soil = True
+
+            additional_data = {}
+            if exist_soil:
+                additional_data["common_data"] = self.get_gg_soil_data(
+                    tag, params={"GG_soil": gg_soil_param, "GG1": gg1_param}
+                )
+
+            else:
+                self.fmanager.input(f"{self.sfcdir}/sfcfile", "sfcdata")
+
+                additional_data["common_data"] = get_and_remove_data("sfcdata")
+
+            if self.exist_snow:
+                additional_data |= self.get_gg_snow_data(
+                    tag, steps, members_dict, self.param_snow
+                )
+                add_additional_file_specific_data(additional_data=additional_data)
+            else:
+                add_additional_data_to_all(tag, steps, members_dict, additional_data)
+
+            move_files(tag, steps, members_dict, self.prepdir)
+        if waitfor_steps:
+            waitfor_files(tag, waitfor_steps, members_dict, self.prepdir)
+
+    def get_spectral_harmonic_data(self):
+        """Get spectral harmonic data."""
+        tag = "ICMSH"
+        steps, waitfor_steps, members_dict, _, _ = get_steps_and_members_to_retrieve(
+            self.steps,
+            self.prepdir,
+            tag,
+            self.bdmember,
+            platform=self.platform,
+            use_lockfile=self.config["boundaries.do_slaf"],
+        )
+
+        if steps:
+            self.get_sh_data(
+                tag,
+                steps,
+                members_dict,
+            )
+
+            additional_data = {}
+            additional_data["common_data"] = self.get_shz_data(tag)
+
+            param_spectral_temperature = None
+            with contextlib.suppress(KeyError):
+                param_spectral_temperature = get_value_from_dict(
+                    self.mars["SH_temperature"], self.init_date_str
+                )
+
+            if param_spectral_temperature:
+                additional_data |= self.get_sh_temperature_data(
+                    tag, steps, members_dict, param_spectral_temperature
+                )
+                add_additional_file_specific_data(additional_data=additional_data)
+
+            else:
+                add_additional_data_to_all(tag, steps, members_dict, additional_data)
+            move_files(tag, steps, members_dict, self.prepdir)
+        if waitfor_steps:
+            waitfor_files(tag, waitfor_steps, members_dict, self.prepdir)
+
+    def get_grid_point_upper_air_data(self):
+        """Get gridpoint upper air data."""
+        tag = "ICMUA"
+        steps, waitfor_steps, members_dict, _, _ = get_steps_and_members_to_retrieve(
+            self.steps,
+            self.prepdir,
+            tag,
+            self.bdmember,
+            platform=self.platform,
+            use_lockfile=self.config["boundaries.do_slaf"],
+        )
+        if steps:
+            self.get_ua_data(tag, steps, members_dict)
+            logger.info(
+                "steps {}, members_dict {}",
+                steps,
+                members_dict,
+            )
+            move_files(tag, steps, members_dict, self.prepdir)
+        if waitfor_steps:
+            waitfor_files(tag, waitfor_steps, members_dict, self.prepdir)
+
+    def get_bdmember_fetch_list(self, bddir: str, bdfile: str):
+        """Builds the list of missing files to fetch from MARS."""
+        mars_file_check_list = {}
+        prep_dir = Path(
+            self.platform.substitute(
+                bddir,
+                basetime=self.boundary.bd_basetime,
+                validtime=self.basetime,
+            )
+        )
+
+        for member in self.bdmember:
+            prep_filename = self.platform.substitute(
+                bdfile.replace("@BDMEMBER@", str(member or 0)),
+                basetime=self.boundary.bd_basetime,
+                validtime=self.basetime,
+            )
+
+            mars_file_check_list[member] = prep_dir / prep_filename
+
+        bdmember_fetch_list = [
+            bdmember
+            for bdmember, mars_file_check in mars_file_check_list.items()
+            if not os.path.exists(mars_file_check)
+        ]
+
+        if not bdmember_fetch_list:
+            logger.info("Prep files already exists as:")
+            for bdmember, filename in mars_file_check_list.items():
+                logger.info(f" {bdmember}: {filename}")
+
+        elif self.split_mars and not self.prep_step:
+            logger.debug("No need Prep file")
+            bdmember_fetch_list = []
+        else:
+            for member in self.bdmember:
+                if member not in bdmember_fetch_list:
+                    logger.info(
+                        "Prep file member={} already exists as {}",
+                        member,
+                        mars_file_check_list[member],
+                    )
+                else:
+                    logger.info(
+                        "Create prep file member={} as {}",
+                        member,
+                        mars_file_check_list[member],
+                    )
+
+        return mars_file_check_list, bdmember_fetch_list
+
+    def get_sfx_data(self):
+        """Get SFX data."""
+        bddir = self.config["system.bddir_sfx"]
+
+        try:
+            if not os.path.exists(bddir):
+                tactusmakedirs(
+                    bddir, unixgroup=self.platform.get_platform_value("unix_group")
+                )
+        except OSError as e:
+            raise RuntimeError(f"Error while preparing the bddir_sfx folder: {e}") from e
+
+        bdfile = self.config["file_templates.bdfile_sfx.archive"]
+        mars_file_check_list, bdmember_fetch_list = self.get_bdmember_fetch_list(
+            bddir, bdfile
+        )
+
+        # Split the lat/lon part and perform it here
+        logger.debug("bdmember_fetch_list: {}", bdmember_fetch_list)
+        if bdmember_fetch_list:
+            self.get_lat_lon_data(bdmember_fetch_list)
+            self.get_geopotential_latlon(self.bdmember[0], bdmember_fetch_list)
+
+        # Get the file list to join
+        for bdmember in bdmember_fetch_list:
+            prep_pattern = f"mars_latlon*_{bdmember or 0}"
+            filenames = list_files_join(self.wdir, prep_pattern)
+            prep_filepath = mars_file_check_list[bdmember]
+            join_files(filenames, prep_filepath)
+
+    def get_sst_data(self):
+        """Get SST data."""
+        bddir_sst = Path(
+            self.platform.substitute(
+                self.config["system.bddir_sst"],
+                basetime=self.boundary.bd_basetime,
+                validtime=self.basetime,
+            )
+        )
+
+        try:
+            if not os.path.exists(bddir_sst):
+                tactusmakedirs(
+                    bddir_sst, unixgroup=self.platform.get_platform_value("unix_group")
+                )
+        except OSError as e:
+            raise RuntimeError(f"Error while preparing the bddir_sst folder: {e}") from e
+
+        bdfile = self.config["file_templates.bdfile_sst.model"]
+
+        (
+            _,
+            _,
+            members_dict,
+            missing_steps_per_member,
+            waitfor_steps_per_member,
+        ) = get_steps_and_members_to_retrieve(
+            self.steps,
+            bddir_sst,
+            bdfile,
+            self.bdmember,
+            platform=self.platform,
+            basetime=self.boundary.bd_basetime,
+            validtime=self.basetime,
+            use_lockfile=self.config["boundaries.do_slaf"],
+        )
+
+        if not missing_steps_per_member:
+            logger.info("All SST files already exists")
+        else:
+            # Get lat lon data
+            self.get_lat_lon_sst_data(missing_steps_per_member, members_dict)
+
+            # Get the file list to join
+            for member in missing_steps_per_member:
+                steps = missing_steps_per_member[member]
+                logger.info(f"Missing steps for member {member}: {steps}")
+                for step in steps:
+                    merge_pattern = f"mars_latlonGG*_{member or 0}+{step}"
+                    filenames = list_files_join(self.wdir, merge_pattern)
+                    sst_filename = self.platform.substitute(
+                        bdfile.replace("@BDMEMBER@", str(member or 0)),
+                        basetime=self.boundary.bd_basetime,
+                        validtime=self.basetime,
+                        bd_index=step,
+                    )
+                    sst_filepath = bddir_sst / sst_filename
+                    join_files(filenames, sst_filepath)
+
+        if waitfor_steps_per_member:
+            # Wait for the relevant files
+            for member in waitfor_steps_per_member:
+                steps = waitfor_steps_per_member[member]
+                for step in steps:
+                    sst_filename = self.platform.substitute(
+                        bdfile.replace("@BDMEMBER@", str(member or 0)),
+                        basetime=self.boundary.bd_basetime,
+                        validtime=self.basetime,
+                        bd_index=step,
+                    )
+                    dest_file = bddir_sst / sst_filename
+                    wait4_file(dest_file)
+                    logger.info(f"Waitfor_steps found: {dest_file}")
+
+    def get_lat_lon_data(self, bdmember_list: List[int]):
+        """Get Lat/Lon data.
+
+        Args:
+            bdmember_list (List[int]): Members to fetch data for
+
+        """
+        prefetch = False
+
+        param = (
+            get_value_from_dict(self.mars["GG"], self.init_date_str)
+            + "/"
+            + get_value_from_dict(self.mars["GG_sea"], self.init_date_str)
+        )
+        if "CY50" in self.config["general.cycle"]:
+            param = "/".join(x for x in param.split("/") if x != "32")
+
+        for member in bdmember_list:
+            data_type = self.mars["type_AN"] if member == 0 else self.mars["type_FC"]
+            # Default to ICMGG_0+* if member is None
+            source = f'"{self.prepdir}/ICMGG_{member or 0}+{self.steps[0]}"'
+            if self.config["boundaries.do_slaf"]:
+                wait4_file(ast.literal_eval(source))
+            self._build_and_run_retrieve_request(
+                req_file_name="latlonGG.req",
+                data_type=data_type,
+                levtype="SFC",
+                param=param,
+                steps=[self.steps[0]],
+                members=[member],
+                target=f"mars_latlonGG_{member or 0}",
+                prefetch=prefetch,
+                specify_domain=True,
+                source=source,
+                write_method=mars_write_method(self.mars_version),
+            )
+            if "CY50" in self.config["general.cycle"]:
+                self._build_and_run_retrieve_request(
+                    req_file_name="latlonGG.req",
+                    data_type=data_type,
+                    levtype="SOL",
+                    param="32",
+                    steps=[self.steps[0]],
+                    members=[member],
+                    target=f"mars_latlonGG_32_{member or 0}",
+                    prefetch=prefetch,
+                    specify_domain=True,
+                    source=source,
+                    write_method=mars_write_method(self.mars_version),
+                )
+
+    def get_lat_lon_sst_data(
+        self,
+        missing_steps_per_member: Dict[int, List[int]],
+        members_dict: Dict[str, List[int]],
+    ):
+        """Get lat/lon data for sst."""
+        tag_mask = "ICMGG_maskland"
+        tag_sea = "sea_latlon"
+        tag_aux = "aux_latlon"
+
+        # JS: MARS 7 doesn't support all the features as supported by MARS 6
+        use_verbose_mode = self.mars_version == 7 or self.config.get(
+            "submission.task_exceptions.Marsprep.verbose_ICMGG_maskland", False
+        )
+
+        if use_verbose_mode:
+            logger.info("MARS request for 'ICMGG_maskland' is using verbose mode")
+
+        prefetch = False
+        param_sea = get_value_from_dict(self.mars["GG_sea"], self.init_date_str)
+        param_lsm = get_value_from_dict(self.mars["GG_lsm"], self.init_date_str)
+        param_skt = get_value_from_dict(self.mars["GG_skt"], self.init_date_str)
+
+        target_aux = "mars_latlonGG"
+        target_maskland = "mars_latlonGG_maskland"
+
+        fieldset_dict = dict.fromkeys(["sic_sst", "lsm"])
+        fieldset_dict["sic_sst"] = {"param": param_sea, "target": target_aux}
+        fieldset_dict["lsm"] = {"param": param_lsm, "target": target_aux}
+
+        for member_type, members in members_dict.items():
+            data_type = (
+                self.mars["type_AN"]
+                if member_type == "control_member"
+                else self.mars["type_FC"]
+            )
+
+            members_to_process = list(set(members) & set(missing_steps_per_member.keys()))
+            for member in members_to_process:
+                # SST/SIC for updating during run (on lat/lon), must be done in loop as
+                # COMPUTE doesn't seem to support multiple steps
+                for step in missing_steps_per_member[member]:
+                    source = compile_target(
+                        f"{self.prepdir}/ICMGG", member_type, member, step
+                    )
+                    target = compile_target(tag_mask, member_type, member, step)
+                    if self.config["boundaries.do_slaf"]:
+                        wait4_file(ast.literal_eval(source))
+
+                    if use_verbose_mode:
+                        # Make an verbose formula
+                        target_striped = target.strip('"')
+                        formula = [
+                            {"formula": '"lsm > 0.5"', "fieldset": "mask"},
+                            {
+                                "formula": '"bitmap(sic, mask)"',
+                                "fieldset": "sic_masked",
+                                "target": f'"sic_{target_striped}"',
+                            },
+                            {
+                                "formula": '"bitmap(sst, mask)"',
+                                "fieldset": "sst_masked",
+                                "target": f'"sst_{target_striped}"',
+                            },
+                        ]
+                    else:
+                        formula = '"bitmap(sic_sst, bitmap(lsm > 0.5, 1))"'
+
+                    # Execute MARS request to mask land
+                    self._build_and_run_compute_request(
+                        req_file_name=f"{tag_mask}.req",
+                        data_type=data_type,
+                        levtype="SFC",
+                        param=None,  # Params are per fieldset defined in fieldset_dict
+                        steps=[step],
+                        target=target,
+                        fieldset_dict=fieldset_dict,
+                        formula=formula,
+                        members=[member],
+                        source=source,
+                        prefetch=prefetch,
+                        specify_domain=False,
+                        write_method=mars_write_method(self.mars_version),
+                    )
+
+                    # Interpolate masked ocean fields
+                    self._build_and_run_retrieve_request(
+                        req_file_name=f"{tag_sea}.req",
+                        data_type=data_type,
+                        levtype="SFC",
+                        param=param_sea,
+                        steps=[step],
+                        target=compile_target(
+                            target_maskland, member_type, member, step=step
+                        ),
+                        members=[member],
+                        source=target,
+                        prefetch=prefetch,
+                        specify_domain=True,
+                        write_method=mars_write_method(self.mars_version),
+                    )
+
+                    # Interpolate lsm & skt
+                    self._build_and_run_retrieve_request(
+                        req_file_name=f"{tag_aux}.req",
+                        data_type=data_type,
+                        levtype="SFC",
+                        param=param_lsm + "/" + param_skt,
+                        steps=[step],
+                        target=compile_target(target_aux, member_type, member, step=step),
+                        members=[member],
+                        source=source,
+                        prefetch=prefetch,
+                        specify_domain=True,
+                        write_method=mars_write_method(self.mars_version),
+                    )
+
+    def get_geopotential_latlon(self, first_member, bdmember_list):
+        """Get geopotential in lat/lon.
+
+        Args:
+            first_member (int): First bdmember in ensemble
+            bdmember_list (List[int]): Members to fetch data for
+
+        """
+        prefetch = False
+        # Retrieve for Surface Geopotential in lat/lon
+        param = get_value_from_dict(self.mars["SHZ"], self.init_date_str)
+        data_type = get_value_from_dict(self.mars["GGZ_type"], self.init_date_str)
+        lev_type = get_value_from_dict(self.mars["Zlev_type"], self.init_date_str)
+
+        if self.use_static_gg_oro:
+            self.fmanager.input(self.gg_oro_source, "gg_oro.Z")
+            z_source = "gg_oro.Z"
+        else:
+            # Default to ICMSH_0+* if member is None
+            z_source = f'"{self.prepdir}/ICMSH_{first_member or 0}+{self.steps[0]}"'
+            if self.config["boundaries.do_slaf"]:
+                wait4_file(ast.literal_eval(z_source))
+        # NOTE: for z, the step is always 0, while steps[0] may be shifted!
+
+        target = f"mars_latlonZ_{first_member or 0}"
+        self._build_and_run_retrieve_request(
+            req_file_name="latlonz.req",
+            data_type=data_type,
+            levtype=lev_type,
+            param=param,
+            steps=[0],
+            members=[first_member],
+            target=target,
+            prefetch=prefetch,
+            specify_domain=True,
+            source=z_source,
+            write_method=mars_write_method(self.mars_version),
+        )
+        for member in bdmember_list:
+            if member == first_member:
+                continue
+            self.fmanager.input(target, f"mars_latlonZ_{member}")
+
+    def get_sh_data(self, tag: str, steps: List[int], members_dict: Dict[str, List[int]]):
+        """Get SH data."""
+        logger.info("Retrieving {} data for steps: {}", tag, steps)
+        param = get_value_from_dict(self.mars["SH"], self.init_date_str)
+
+        for member_type, members in members_dict.items():
+            data_type = (
+                self.mars["type_AN"]
+                if member_type == "control_member"
+                else self.mars["type_FC"]
+            )
+            self._build_and_run_retrieve_request(
+                req_file_name=f"{member_type}_{tag}.req",
+                data_type=data_type,
+                levtype="ML",
+                param=param,
+                steps=steps,
+                members=members,
+                target=compile_target(tag, member_type, members),
+                grid=self.mars["grid_ML"],
+            )
+
+    def get_sh_temperature_data(
+        self, tag: str, steps: List[int], members_dict: Dict[str, List[int]], param
+    ):
+        """Get soil gridpoint data."""
+        additional_data: Dict[str, bytes] = {}
+        for member_type, members in members_dict.items():
+            data_type = (
+                self.mars["type_AN"]
+                if member_type == "control_member"
+                else self.mars["type_FC"]
+            )
+            self._build_and_run_retrieve_request(
+                req_file_name=f"{member_type}_{tag}.temp.req",
+                data_type=data_type,
+                levtype="ML",
+                param=param,
+                steps=steps,
+                members=members,
+                target=compile_target(f"{tag}.temperature", member_type, members),
+            )
+
+            for step in steps:
+                for member in members:
+                    # Default to "*_0+{step}" if member is None
+                    key = f"{tag}_{member or 0}+{step}"
+                    file_temperature = f"{tag}.temperature_{member or 0}+{step}"
+                    additional_data[key] = get_and_remove_data(file_temperature)
+
+        return additional_data
+
+    def get_shz_data(self, tag: str):
+        """Get geopotential in spherical harmonics."""
+        if self.use_static_sh_oro:
+            self.fmanager.input(self.sh_oro_source, f"{tag}.Z")
+
+        else:
+            param = get_value_from_dict(self.mars["SHZ"], self.init_date_str)
+            self._build_and_run_retrieve_request(
+                req_file_name=f"{tag}Z.req",
+                data_type=self.mars["SHZ_type"],
+                levtype="ML",
+                param=param,
+                steps=[0],
+                target=f'"{tag}.Z"',
+                grid=self.mars["grid_ML"],
+            )
+
+        return get_and_remove_data(f"{tag}.Z")
+
+    def get_ua_data(self, tag: str, steps: List[int], members_dict: Dict[str, List[int]]):
+        """Get upper air data."""
+        logger.info("Retrieving {} data for steps: {}", tag, steps)
+        param = get_value_from_dict(self.mars["UA"], self.init_date_str)
+
+        for member_type, members in members_dict.items():
+            data_type = (
+                self.mars["type_AN"]
+                if member_type == "control_member"
+                else self.mars["type_FC"]
+            )
+            self._build_and_run_retrieve_request(
+                req_file_name=f"{member_type}_{tag}.req",
+                data_type=data_type,
+                levtype="ML",
+                param=param,
+                steps=steps,
+                members=members,
+                target=compile_target(tag, member_type, members),
+                grid=self.mars["grid_ML"],
+            )
+
+    def get_gg_data(self, tag: str, steps: List[int], members_dict: Dict[str, List[int]]):
+        """Get gridpoint surface data."""
+        logger.info("Retrieving {} data for steps: {}", tag, steps)
+        param = (
+            get_value_from_dict(self.mars["GG"], self.init_date_str)
+            + "/"
+            + get_value_from_dict(self.mars["GG_sea"], self.init_date_str)
+        )
+
+        for member_type, members in members_dict.items():
+            data_type = (
+                self.mars["type_AN"]
+                if member_type == "control_member"
+                else self.mars["type_FC"]
+            )
+
+            self._build_and_run_retrieve_request(
+                req_file_name=f"{member_type}_{tag}.req",
+                data_type=data_type,
+                levtype="SFC",
+                param=param,
+                steps=steps,
+                members=members,
+                target=compile_target(tag, member_type, members),
+            )
+
+    def get_gg_soil_data(self, tag: str, params: dict):
+        """Get soil gridpoint data."""
+        for param_name, param in params.items():
+            target = f"{tag}.{param_name}"
+            self._build_and_run_retrieve_request(
+                req_file_name=f"{target}.req",
+                data_type=self.mars["type_AN"],
+                levtype="SFC",
+                param=param,
+                steps=[0],
+                target=target,
+            )
+        # Collect and return the data from target files
+        # (Read the single-step MARS files first, hence the reversed order)
+        data = b""
+        for param_name in reversed(params.keys()):
+            target = f"{tag}.{param_name}"
+            data += get_and_remove_data(target)
+        return data
+
+    def get_gg_snow_data(
+        self, tag: str, steps: List[int], members_dict: Dict[str, List[int]], param
+    ):
+        """Get soil gridpoint data."""
+        additional_data: Dict[str, bytes] = {}
+        for member_type, members in members_dict.items():
+            data_type = (
+                self.mars["type_AN"]
+                if member_type == "control_member"
+                else self.mars["type_FC"]
+            )
+            self._build_and_run_retrieve_request(
+                req_file_name=f"{member_type}_{tag}.snow.req",
+                data_type=data_type,
+                levtype="SOL",
+                param=param,
+                steps=steps,
+                members=members,
+                target=compile_target(f"{tag}.snow", member_type, members),
+            )
+
+            for step in steps:
+                for member in members:
+                    # Default to "*_0+{step}" if member is None
+                    key = f"{tag}_{member or 0}+{step}"
+                    file_snow = f"{tag}.snow_{member or 0}+{step}"
+                    additional_data[key] = get_and_remove_data(file_snow)
+
+        return additional_data
+
+    def get_observations(
+        self, tag: str
+    ):
+        """Get observations."""
+        data_type = self.mars["type_OB"] 
+        obstype = self.mars["obstype"]
+        repres = self.mars["repres"]
+        range = self.mars["range"]
+        self._build_and_run_retrieve_request(
+            req_file_name=f"{tag}.obs.req",
+            data_type=data_type,
+            obstype=obstype,
+            repres=repres,
+            range=range,
+            target=f"{tag}.obs",
+            specify_domain=True,
+            obsretrieve=True,
+        )
+
+        # Do we need a special function to move the file to ob_dir?
+        #move_files(tag, steps, members_dict, self.obsdir)
+        file_name = f"{tag}.obs"
+        dest_file = self.obsdir / file_name
+        if os.path.exists(file_name):
+             shutil.move(file_name, dest_file)
+
+    def _build_retrieve_request(
+        self,
+        data_type: str,
+        levtype: str,
+        param: str,
+        steps: List[int],
+        target: str,
+        members: Optional[List[int]] = None,
+        source: Optional[str] = None,
+        prefetch: bool = True,
+        specify_domain: bool = False,
+        grid: Optional[str] = None,
+        fieldset: Optional[str] = None,
+        range: Optional[str] = None,
+        repres: Optional[str] = None,
+        obstype: Optional[List[str]] = None,
+        obsretrieve: bool = False,
+    ) -> BaseRequest:
+        """Build request to retrieve data from mars.
+
+        Args:
+            data_type: Data type.
+            levtype: Level type.
+            param: Parameter(s) to retrieve.
+            steps: Steps to retrieve.
+            target: Name of the target file.
+            members: Members to retrieve data from.
+            source: Source file to retrieve data from.
+            prefetch: Prefetch.
+            specify_domain: Whether to specify domain or not.
+            grid: The grid to use.
+            fieldset: Name of fieldset. Defaults None.
+            range: time range in minutes for the obs window 
+            repres: format of observations 
+            obstype: observation types 
+            obsretrieve: Whether to do a obs retrieve or not
+
+        Returns:
+            request: BaseRequest to retrieve data
+
+        """
+        request = BaseRequest(
+            class_=self.mars["class"],
+            data_type=data_type,
+            expver=self.mars["expver"],
+            levtype=levtype,
+            date=self.init_date_str,
+            time=self.init_hour_str,
+            steps=steps,
+            param=param,
+            target=target,
+            range=range,
+            repres=repres,
+            obstype=obstype,
+        )
+        self.update_data_request(
+            request,
+            prefetch=prefetch,
+            specify_domain=specify_domain,
+            bdmember=members,
+            grid=grid,
+            source=source,
+            fieldset=fieldset,
+            obsretrieve=obsretrieve,
+        )
+
+        return request
+
+    def _run_request_file(
+        self,
+        req_file_name: str,
+    ) -> None:
+        """Run request to retrieve data from mars.
+
+        Args:
+            req_file_name: Name of the request file.
+        """
+        BatchJob(os.environ, wrapper=self.wrapper).run(
+            f"{self.get_binary('mars')} {req_file_name}"
+        )
+
+    def _build_and_run_retrieve_request(
+        self,
+        req_file_name: str,
+        data_type: str,
+        levtype: Optional[str] = None,
+        param: Optional[str] = None,
+        steps: Optional[List[int]] = None,
+        target: Optional[str] = None,
+        members: Optional[List[int]] = None,
+        source: Optional[str] = None,
+        prefetch: bool = True,
+        specify_domain: bool = False,
+        write_method: str = "retrieve",
+        grid: Optional[str] = None,
+        range: Optional[str] = None,
+        repres: Optional[str] = None,
+        obstype: Optional[List[str]] = None,
+        obsretrieve: bool = False,
+    ) -> None:
+        """Build and run request to retrieve data from mars.
+
+        Args:
+            req_file_name: Name of the request file.
+            data_type: Data type.
+            levtype: Level type.
+            param: Parameter(s) to retrieve.
+            steps: Steps to retrieve.
+            target: Name of the target file.
+            members: Members to retrieve data from.
+            source: Source file to retrieve data from.
+            prefetch: Prefetch.
+            specify_domain: Whether to specify domain or not.
+            write_method: The write method to use when writing the request to file.
+            grid: The grid to use.
+            range: time range in minutes for the obs window
+            repres: format of observations
+            obstype: observation types
+            obsretrieve: Whether to do an obs retrieve or not
+        """
+        request = self._build_retrieve_request(
+            data_type,
+            levtype,
+            param,
+            steps,
+            target,
+            members,
+            source,
+            prefetch,
+            specify_domain,
+            grid,
+            obstype=obstype,
+            repres=repres,
+            range=range,
+            obsretrieve=obsretrieve,
+        )
+
+        # Write the request to file
+        write_retrieve_mars_req(request, req_file_name, write_method)
+
+        # Execute written request
+        self._run_request_file(req_file_name)
+
+    def _build_and_run_compute_request(
+        self,
+        req_file_name: str,
+        data_type: str,
+        levtype: str,
+        param: str,
+        steps: List[int],
+        target: str,
+        fieldset_dict: dict,
+        formula: str | List[Dict],
+        members: Optional[List[int]] = None,
+        source: Optional[str] = None,
+        prefetch: bool = True,
+        specify_domain: bool = False,
+        write_method: str = "retrieve",
+        grid: Optional[str] = None,
+    ) -> None:
+        """Build and run request to retrieve and process data from mars.
+
+        Args:
+            req_file_name: Name of the request file.
+            data_type: Data type.
+            levtype: Level type.
+            param: Parameter(s) to retrieve.
+            steps: Steps to retrieve.
+            target: Name of the target file.
+            fieldset_dict: Dict with fieldset and fieldset-specific data
+            formula: Formula for compute (or list of dics with formulas and fieldsets).
+            members: Members to retrieve data from.
+            source: Source file to retrieve data from.
+            prefetch: Prefetch.
+            specify_domain: Whether to specify domain or not.
+            write_method: The write method to use when writing the request to file.
+            grid: The grid to use.
+        """
+        # First request will write to a new file
+        omode = "w"
+
+        use_verbose_mode = isinstance(formula, list)
+
+        for fieldset, fieldset_data in fieldset_dict.items():
+            fieldset_param = param
+            if "param" in fieldset_data:
+                fieldset_param = fieldset_data["param"]
+
+            fieldset_target = target
+            if "target" in fieldset_data:
+                fieldset_target = fieldset_data["target"]
+
+            if use_verbose_mode:
+                # MARS version 7 cannot handle reading multiple PARMS to one FIELDSET,
+                # so split them into multiple requests
+                fieldset_param_list = fieldset_param.split("/")
+                fieldset_name_list = fieldset.split("_")
+                if len(fieldset_param_list) != len(fieldset_name_list):
+                    # Cannot split request into mulpile
+                    logger.error(
+                        (
+                            "Cannot split MARS request; number of PARAMs (="
+                            f"{len(fieldset_param_list)}"
+                            ") and FIELDSETs (="
+                            f"{len(fieldset_name_list)}"
+                            ") not equal"
+                        )
+                    )
+            else:
+                fieldset_param_list = [fieldset_param]
+                fieldset_name_list = [fieldset]
+
+            for single_param, single_fieldset in zip(
+                fieldset_param_list, fieldset_name_list
+            ):
+                request = self._build_retrieve_request(
+                    data_type,
+                    levtype,
+                    single_param,
+                    steps,
+                    fieldset_target,
+                    members,
+                    source,
+                    prefetch,
+                    specify_domain,
+                    grid,
+                    single_fieldset,
+                )
+
+                # Write/append request to file
+                write_retrieve_mars_req(request, req_file_name, write_method, omode)
+
+                # All upcomming requests will be appened to the same file
+                omode = "a"
+
+        # Write/append compute request to file
+        if use_verbose_mode:
+            for formula_part in formula:
+                if "fieldset" in formula_part:
+                    write_compute_mars_req(
+                        req_file_name,
+                        formula=formula_part["formula"],
+                        fieldset=formula_part["fieldset"],
+                        omode=omode,
+                    )
+
+                if "target" in formula_part:
+                    write_write_mars_req(
+                        req_file_name,
+                        fieldset=formula_part["fieldset"],
+                        target=formula_part["target"],
+                        omode=omode,
+                    )
+        else:
+            write_compute_mars_req(
+                req_file_name, formula=formula, target=target, omode=omode
+            )
+
+        # Execute written request
+        self._run_request_file(req_file_name)
+
+        if use_verbose_mode:
+            # Join different output files
+            generated_files = [
+                formula_part.get("target").strip('"')
+                for formula_part in formula
+                if formula_part.get("target") is not None
+            ]
+            join_files(generated_files, target.strip('"'))


### PR DESCRIPTION

This is a draft PR. There is code that has to be cleaned/reorganized. Main points:

Task Marsobs has been created within the tactus DA suite. The references for this work have been the task Marsprep from tactus and the Harmonie MARS syntax to get the data. Currently an obs file with conventional observations is downloaded from MARS and stored in ob_dir

This is a first development that should be refined to integrate in a cleaner or more general way both Marsprep and Marsobs and associated functions. In particular marsobs.py should be cleaned/simplified, because there is a lot of code not used.

The main function that makes the work in marsobs.py is named get_observations.

Need to test Canari and Oopsvar work with this obs file. To do this is needed to give to the obs file a name and dir structure for ObsConvert to be able to read it.

Note: Although we are not doing any assimilation, I need to use te assimilation.toml config file for at least to use the da.ob_dir variable, which contains the path where the obs file will be stored.

Reviewers
-----------

I suggest @kastelecn and @trygveasp to review this PR
