### PR TITLE
Introduce end relative to start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce perturbation family and config section. [#87](https://github.com/ACCORD-NWP/tactus/pull/87) (@uandrae)
 
 ### Changed
+- Make general.times.end relative to general.times.start when defined as duration. [#101](https://github.com/ACCORD-NWP/tactus/pull/101) (@uandrae)
 - Update CY50t2 surfex namelists to make LAM -> LAM work. [#99](https://github.com/ACCORD-NWP/tactus/pull/99) (@uandrae)
 - Switch to accord owned path for static data on atos_bologna. [#106](https://github.com/ACCORD-NWP/tactus/pull/106) (@uandrae)
 

--- a/tactus/data/config_files/config_file_schemas/main_config_schema.json
+++ b/tactus/data/config_files/config_file_schemas/main_config_schema.json
@@ -901,7 +901,7 @@
                 },
                 {
                   "format": "duration",
-		  "pattern": "^P"
+                  "pattern": "^P"
                 }
               ]
             },

--- a/tactus/data/config_files/config_file_schemas/main_config_schema.json
+++ b/tactus/data/config_files/config_file_schemas/main_config_schema.json
@@ -881,6 +881,9 @@
                 },
                 {
                   "format": "duration"
+                },
+                {
+                  "pattern": "^relative_to_start(.*)"
                 }
               ]
             },

--- a/tactus/data/config_files/config_file_schemas/main_config_schema.json
+++ b/tactus/data/config_files/config_file_schemas/main_config_schema.json
@@ -904,8 +904,7 @@
                   "format": "date-time"
                 },
                 {
-                  "format": "duration",
-                  "pattern": "^P"
+                  "format": "duration"
                 }
               ]
             },

--- a/tactus/data/config_files/config_file_schemas/main_config_schema.json
+++ b/tactus/data/config_files/config_file_schemas/main_config_schema.json
@@ -893,17 +893,15 @@
               ]
             },
             "end": {
-              "description": "End time if the run covers several cycles. Same format as start",
+              "description": "End time if the run covers several cycles. Date time format or duration relative start.",
               "type": "string",
               "oneOf": [
                 {
                   "format": "date-time"
                 },
                 {
-                  "format": "duration"
-                },
-                {
-                  "pattern": "^relative_to_start(.*)"
+                  "format": "duration",
+		  "pattern": "^P"
                 }
               ]
             },

--- a/tactus/data/config_files/modifications/target.toml
+++ b/tactus/data/config_files/modifications/target.toml
@@ -3,7 +3,7 @@
 
 [general.times]
   cycle_length = "PT1H"
-  end = "2025-02-09T02:00:00Z"
+  end = "PT1H"
   forecast_range = "PT3H"
   start = "2025-02-09T01:00:00Z"
 

--- a/tactus/datetime_utils.py
+++ b/tactus/datetime_utils.py
@@ -249,7 +249,7 @@ def get_month_list(start, end) -> list:
     ]
 
 
-def evaluate_date(date: str) -> str:
+def evaluate_date(date: str, reference_date=None) -> str:
     """Parses an ISO 8601 datetime and/or duration and returns the computed datetime.
 
     - If the input is a datetime (e.g., "2025-03-19T00:00:00Z"), it returns it as-is.
@@ -260,6 +260,7 @@ def evaluate_date(date: str) -> str:
 
     Args:
         date (str): An ISO 8601 datetime, duration, or both.
+        reference_date (str): An ISO 8601 datetime, duration, or both.
 
     Returns:
         str: The computed datetime in ISO format.
@@ -276,11 +277,14 @@ def evaluate_date(date: str) -> str:
         )
 
     if date.startswith(("P", "-P")):
-        today_midnight = datetime.now(timezone.utc).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
+        if reference_date is None:
+            _reference_date = datetime.now(timezone.utc).replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
+        else:
+            _reference_date = as_datetime(evaluate_date(reference_date))
         return (
-            (today_midnight + isodate.parse_duration(date))
+            (_reference_date + isodate.parse_duration(date))
             .isoformat(timespec="seconds")
             .replace("+00:00", "Z")
         )

--- a/tactus/datetime_utils.py
+++ b/tactus/datetime_utils.py
@@ -278,9 +278,10 @@ def evaluate_date(date: str, reference_date=None) -> str:
 
     if date.startswith(("P", "-P")):
         if reference_date is None:
-            _reference_date = datetime.now(timezone.utc).replace(
+            today_midnight = datetime.now(timezone.utc).replace(
                 hour=0, minute=0, second=0, microsecond=0
             )
+            _reference_date = today_midnight
         else:
             _reference_date = as_datetime(evaluate_date(reference_date))
         return (

--- a/tactus/derived_variables.py
+++ b/tactus/derived_variables.py
@@ -196,12 +196,8 @@ def derived_variables(config, processor_layout=None):
         )
         raise NotImplementedError(msg)
 
-    xlat0 = config.get("domain.xlat0", "")
-    xlon0 = config.get("domain.xlon0", "")
-    if not xlat0:
-        xlat0 = config.get("domain.xlatcen")
-    if not xlon0:
-        xlon0 = config.get("domain.xloncen")
+    xlat0 = config.get("domain.xlat0", config.get("domain.xlatcen"))
+    xlon0 = config.get("domain.xlon0", config.get("domain.xloncen"))
 
     pi = 4.0 * atan(1.0)
     xrpk = sin(float(xlat0) * pi / 180.0)

--- a/tactus/derived_variables.py
+++ b/tactus/derived_variables.py
@@ -38,6 +38,12 @@ def set_times(config):
     if "start" not in times:
         times.update({"start": times["basetime"]})
         logger.debug("Set start to {}", times["start"])
+
+    if "end" in times and times["end"].startswith("relative_to_start."):
+        end = times["end"].replace("relative_to_start.", "")
+        end = as_datetime(times["start"]) + as_timedelta(end)
+        times["end"] = end.strftime("%Y-%m-%dT%H:%M:%SZ")
+
     if "end" not in times:
         times.update({"end": times["basetime"]})
         logger.debug("Set end to {}", times["end"])
@@ -195,8 +201,12 @@ def derived_variables(config, processor_layout=None):
         )
         raise NotImplementedError(msg)
 
-    xlat0 = config.get("domain.xlat0", config.get("domain.xlatcen"))
-    xlon0 = config.get("domain.xlon0", config.get("domain.xloncen"))
+    xlat0 = config.get("domain.xlat0", "")
+    xlon0 = config.get("domain.xlon0", "")
+    if not xlat0:
+        xlat0 = config.get("domain.xlatcen")
+    if not xlon0:
+        xlon0 = config.get("domain.xloncen")
 
     pi = 4.0 * atan(1.0)
     xrpk = sin(float(xlat0) * pi / 180.0)

--- a/tactus/derived_variables.py
+++ b/tactus/derived_variables.py
@@ -39,11 +39,6 @@ def set_times(config):
         times.update({"start": times["basetime"]})
         logger.debug("Set start to {}", times["start"])
 
-    if "end" in times and times["end"].startswith("relative_to_start."):
-        end = times["end"].replace("relative_to_start.", "")
-        end = as_datetime(times["start"]) + as_timedelta(end)
-        times["end"] = end.strftime("%Y-%m-%dT%H:%M:%SZ")
-
     if "end" not in times:
         times.update({"end": times["basetime"]})
         logger.debug("Set end to {}", times["end"])

--- a/tactus/derived_variables.py
+++ b/tactus/derived_variables.py
@@ -44,7 +44,7 @@ def set_times(config):
         logger.debug("Set end to {}", times["end"])
 
     times.update({"start": evaluate_date(times["start"])})
-    times.update({"end": evaluate_date(times["end"])})
+    times.update({"end": evaluate_date(times["end"], reference_date=times["start"])})
 
     if as_datetime(times["start"]) > as_datetime(times["end"]):
         raise ValueError(

--- a/tactus/experiment.py
+++ b/tactus/experiment.py
@@ -57,7 +57,12 @@ class Exp:
             config = config.copy(
                 update={
                     "general": {
-                        "times": {"end": evaluate_date(config["general.times.end"])}
+                        "times": {
+                            "end": evaluate_date(
+                                config["general.times.end"],
+                                reference_date=config["general.times.start"],
+                            )
+                        }
                     }
                 }
             )

--- a/tactus/experiment.py
+++ b/tactus/experiment.py
@@ -54,8 +54,13 @@ class Exp:
                     }
                 }
             )
-            general = set_times(config)
-            config = config.copy(update={"general": {"times": general["times"]["end"]}})
+            config = config.copy(
+                update={
+                    "general": {
+                        "times": {"end": evaluate_date(config["general.times.end"])}
+                    }
+                }
+            )
 
         self.config = config
 

--- a/tactus/experiment.py
+++ b/tactus/experiment.py
@@ -54,13 +54,8 @@ class Exp:
                     }
                 }
             )
-            config = config.copy(
-                update={
-                    "general": {
-                        "times": {"end": evaluate_date(config["general.times.end"])}
-                    }
-                }
-            )
+            general = set_times(config)
+            config = config.copy(update={"general": {"times": general["times"]["end"]}})
 
         self.config = config
 

--- a/tactus/toolbox.py
+++ b/tactus/toolbox.py
@@ -16,7 +16,7 @@ from isodate import parse_duration
 from troika.connections.ssh import SSHConnection
 
 from .csc_actions import SelectTstep
-from .datetime_utils import as_datetime, get_decade, oi2dt_list
+from .datetime_utils import as_datetime, evaluate_date, get_decade, oi2dt_list
 from .logs import logger
 from .os_utils import tactusmakedirs
 
@@ -609,7 +609,8 @@ class Platform:
 
             end = self.config.get("general.times.end", None)
             if end is not None:
-                pattern = self.substitute_datetime(pattern, as_datetime(end), "_END")
+                _end = evaluate_date(end, reference_date=start)
+                pattern = self.substitute_datetime(pattern, as_datetime(_end), "_END")
 
         forecast_range = self.config.get("general.times.forecast_range", None)
         if isinstance(forecast_range, str):

--- a/tactus/toolbox.py
+++ b/tactus/toolbox.py
@@ -608,7 +608,7 @@ class Platform:
                 pattern = self.substitute_datetime(pattern, as_datetime(start), "_START")
 
             end = self.config.get("general.times.end", None)
-            if end is not None and not end.startswith("relative_to_start"):
+            if end is not None:
                 pattern = self.substitute_datetime(pattern, as_datetime(end), "_END")
 
         forecast_range = self.config.get("general.times.forecast_range", None)

--- a/tactus/toolbox.py
+++ b/tactus/toolbox.py
@@ -608,7 +608,7 @@ class Platform:
                 pattern = self.substitute_datetime(pattern, as_datetime(start), "_START")
 
             end = self.config.get("general.times.end", None)
-            if end is not None:
+            if end is not None and not end.startswith("relative_to_start"):
                 pattern = self.substitute_datetime(pattern, as_datetime(end), "_END")
 
         forecast_range = self.config.get("general.times.forecast_range", None)

--- a/tests/unit/test_derived_variables.py
+++ b/tests/unit/test_derived_variables.py
@@ -5,18 +5,22 @@ import re
 
 import pytest
 
-from tactus.config_parser import ConfigFileValidationError
 from tactus.derived_variables import derived_variables, set_times
 
 
-def test_set_times(default_config):
+@pytest.fixture(params=["2026-06-11T00:00:00Z", "-P1D", "PT1H"])
+def start(request):
+    return request.param
+
+
+def test_set_times_varying_start(default_config, start):
     config = default_config.copy(
-        update={"general": {"times": {"end": "P1D", "start": "P2D"}}}
+        update={"general": {"times": {"end": "P1D", "start": start}}}
     )
     config = set_times(config)
 
 
-def test_set_end_less_than_start(default_config):
+def test_set_end_less_than_start_aborts(default_config):
     config = default_config.copy(
         update={
             "general": {
@@ -28,12 +32,12 @@ def test_set_end_less_than_start(default_config):
         config = set_times(config)
 
 
-def test_set_negative_end(default_config):
+def test_set_negative_end_aborts(default_config):
+    config = default_config.copy(update={"general": {"times": {"end": "-P1D"}}})
     with pytest.raises(
-        ConfigFileValidationError,
-        match=re.escape("must be valid exactly by one definition"),
+        ValueError, match=re.escape("cannot be larger than general.times.end")
     ):
-        default_config.copy(update={"general": {"times": {"end": "-P1D"}}})
+        config = set_times(config)
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/test_derived_variables.py
+++ b/tests/unit/test_derived_variables.py
@@ -9,6 +9,14 @@ from tactus.config_parser import ConfigFileValidationError
 from tactus.derived_variables import derived_variables, set_times
 
 
+def test_set_times(default_config):
+    config = default_config.copy(
+        update={"general": {"times": {"end": "P1D", "start": "P2D"}}}
+    )
+    with pytest.raises(ValueError, match=re.escape("cannot be larger than")):
+        config = set_times(config)
+
+
 def test_set_end_less_than_start(default_config):
     config = default_config.copy(
         update={

--- a/tests/unit/test_derived_variables.py
+++ b/tests/unit/test_derived_variables.py
@@ -5,15 +5,28 @@ import re
 
 import pytest
 
+from tactus.config_parser import ConfigFileValidationError
 from tactus.derived_variables import derived_variables, set_times
 
 
-def test_set_times(default_config):
+def test_set_end_less_than_start(default_config):
     config = default_config.copy(
-        update={"general": {"times": {"end": "P1D", "start": "P2D"}}}
+        update={
+            "general": {
+                "times": {"end": "2026-06-06T00:00:00Z", "start": "2026-06-07T00:00:00Z"}
+            }
+        }
     )
     with pytest.raises(ValueError, match=re.escape("cannot be larger than")):
         config = set_times(config)
+
+
+def test_set_negative_end(default_config):
+    with pytest.raises(
+        ConfigFileValidationError,
+        match=re.escape("must be valid exactly by one definition"),
+    ):
+        default_config.copy(update={"general": {"times": {"end": "-P1D"}}})
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/test_derived_variables.py
+++ b/tests/unit/test_derived_variables.py
@@ -13,8 +13,7 @@ def test_set_times(default_config):
     config = default_config.copy(
         update={"general": {"times": {"end": "P1D", "start": "P2D"}}}
     )
-    with pytest.raises(ValueError, match=re.escape("cannot be larger than")):
-        config = set_times(config)
+    config = set_times(config)
 
 
 def test_set_end_less_than_start(default_config):


### PR DESCRIPTION
## Describe your changes
Changes the convention for  `general.times.end` to make it relative to `general.times.start` when express in duration notation. The background is the need in testing over more than one cycle and where the start date is not known. 

The need for this functionality will be introduced in #88. 

< Please also include relevant motivation and context. >

< List any dependencies that are required for this change. >

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

### Testing

- [ ] I have tested this on ATOS using the `atos_bologna.toml` configuration in the latest version of [Tactus-test-runner](https://github.com/destination-earth-digital-twins/Tactus-test-runner)
- [ ] I have tested this on LUMI using the `lumi.toml` configuration in the latest version of [Tactus-test-runner](https://github.com/destination-earth-digital-twins/Tactus-test-runner)

For further information see the [development guide](https://github.com/ACCORD-NWP/tactus/blob/develop/docs/markdown_docs/development_guide.md)

### Code quality

- [ ] My change follows the [best practices for this project](https://github.com/ACCORD-NWP/tactus/blob/develop/docs/markdown_docs/development_guide.md#best-practices).
- [ ] My local environment is correctly initialised as described in the [README](https://github.com/ACCORD-NWP/tactus/blob/develop/README.md) file.
- [ ] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation and docstrings to reflect the changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have ensured that the code is still installable with `poetry` after the changes and runs
- [ ] I have requested one or more reviewer(s) and an assignee (assignee is responsible for merging). At least one reviewer has accepted to review.

## Checklist for reviewers
Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code readable
- [ ] the code well tested (checked coverage report)
- [ ] the code documented
- [ ] the code easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change (in section
  reflecting type of change, for example "bug fixes", add section where
  missing)

## Checklist for assignees
- [ ] PR is up to date with the base branch
- [ ] the tests passing
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- [ ] the PR has been approved by all the reviewers, that accepted to review.
- Once the PR ready to be merged, squash commits and merge the PR.

## Tag possible reviewers
You can @-tag people to review this PR in addition to formal review requests.
