### PR TITLE
Correct basetime used for mars availability check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switch to accord owned path for static data on atos_bologna. [#106](https://github.com/ACCORD-NWP/tactus/pull/106) (@uandrae)
 
 ### Fixed
+- Correct basetime used for MARS data availability. [#108](https://github.com/ACCORD-NWP/tactus/pull/108) (@uandrae)
 - Correct input data path in E923Update. [#100](https://github.com/ACCORD-NWP/tactus/pull/100) (@uandrae)
 - Fix documentation deployment trigger on new releases. [#107](https://github.com/ACCORD-NWP/tactus/pull/107) (@mfroelund)
 - Fix ordering of setting `productDefinitionTemplateNumber` for EPS runs in `FaModelSource.yml`[\#91](https://github.com/ACCORD-NWP/tactus/pull/91) (@sbnielsen)

--- a/tactus/tasks/marsprep.py
+++ b/tactus/tasks/marsprep.py
@@ -98,11 +98,12 @@ class Marsprep(Task):
         self.basetime = as_datetime(self.config["general.times.basetime"])
         forecast_range = as_timedelta(self.config["general.times.forecast_range"])
 
+        # Get boundary informations
+        self.boundary = Boundary(config)
+
         # Check if there are data for specific date in mars
         check_data_available(self.boundary.bd_basetime, self.mars)
 
-        # Get boundary informations
-        self.boundary = Boundary(config)
         self.steps = get_steplist(
             self.boundary.bd_offset, forecast_range, self.boundary.bdint
         )

--- a/tactus/tasks/marsprep.py
+++ b/tactus/tasks/marsprep.py
@@ -99,7 +99,7 @@ class Marsprep(Task):
         forecast_range = as_timedelta(self.config["general.times.forecast_range"])
 
         # Check if there are data for specific date in mars
-        check_data_available(self.basetime, self.mars)
+        check_data_available(self.boundary.bd_basetime, self.mars)
 
         # Get boundary informations
         self.boundary = Boundary(config)


### PR DESCRIPTION
## Describe your changes
For `boundaries.ifs.selection=iyzp` we have data for a sinlge date: `2023-08-20T00:00:00Z`. For a run that we start at 12Z we currently get: 
``
`ValueError: No data for 2023-08-20 12:00:00+00:00! The data is available between 2023-08-20 00:00:00+00:00 and 2023-08-20 00:00:00+00:00.
```
although we should have picked up the 00Z run. This PR fixes this problem.

< Summary of the changes.>

< Please also include relevant motivation and context. >

< List any dependencies that are required for this change. >

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

### Testing

- [ ] I have tested this on ATOS using the `atos_bologna.toml` configuration in the latest version of [Tactus-test-runner](https://github.com/destination-earth-digital-twins/Tactus-test-runner)
- [ ] I have tested this on LUMI using the `lumi.toml` configuration in the latest version of [Tactus-test-runner](https://github.com/destination-earth-digital-twins/Tactus-test-runner)

For further information see the [development guide](https://github.com/ACCORD-NWP/tactus/blob/develop/docs/markdown_docs/development_guide.md)

### Code quality

- [ ] My change follows the [best practices for this project](https://github.com/ACCORD-NWP/tactus/blob/develop/docs/markdown_docs/development_guide.md#best-practices).
- [ ] My local environment is correctly initialised as described in the [README](https://github.com/ACCORD-NWP/tactus/blob/develop/README.md) file.
- [ ] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation and docstrings to reflect the changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have ensured that the code is still installable with `poetry` after the changes and runs
- [ ] I have requested one or more reviewer(s) and an assignee (assignee is responsible for merging). At least one reviewer has accepted to review.

## Checklist for reviewers
Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code readable
- [ ] the code well tested (checked coverage report)
- [ ] the code documented
- [ ] the code easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change (in section
  reflecting type of change, for example "bug fixes", add section where
  missing)

## Checklist for assignees
- [ ] PR is up to date with the base branch
- [ ] the tests passing
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- [ ] the PR has been approved by all the reviewers, that accepted to review.
- Once the PR ready to be merged, squash commits and merge the PR.

## Tag possible reviewers
You can @-tag people to review this PR in addition to formal review requests.
