### PR TITLE
Test runner - display summary of all tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce CY50t2 test cases in the test-runner. [\#88](https://github.com/ACCORD-NWP/tactus/pull/88) (@uandrae)
 - Added suite control switch for grib calculations. [#102](https://github.com/ACCORD-NWP/tactus/pull/102) (@uandrae)
 - Introduce perturbation family and config section. [#87](https://github.com/ACCORD-NWP/tactus/pull/87) (@uandrae)
+- Test runner - display summary of all tests. [#129](https://github.com/ACCORD-NWP/tactus/pull/129/)(@dhaumont)
 
 ### Changed
 - Let the DKCOEXP be the default large domain. [\#116](https://github.com/ACCORD-NWP/tactus/pull/116)(@uandrae)

--- a/tactus/argparse_wrapper.py
+++ b/tactus/argparse_wrapper.py
@@ -491,7 +491,8 @@ def get_args_parser(program_name=GeneralConstants.PACKAGE_NAME):
         "--config-file",
         "-c",
         dest="config_file",
-        help="Test runner config file",
+        help="Test runner config file. A summary of tests results will be displayed "
+        + "if only this option is given",
         required=False,
         default=None,
     )

--- a/tactus/datetime_utils.py
+++ b/tactus/datetime_utils.py
@@ -68,6 +68,29 @@ def dt2str(dt):
     return f"{h:04d}:{m:02d}:{s:02d}"
 
 
+def since_str(datetime: datetime, now: datetime) -> str:
+    """Convert a datetime to a human-readable string indicating how long ago it was.
+
+    Args:
+        datetime (datetime): The datetime object.
+        now (datetime): The current datetime object.
+
+    Returns:
+        str: A human-readable string indicating how long ago datetime now was
+    """
+    timestamp = int((now - datetime).total_seconds())
+    if timestamp < 60:
+        return "Now"
+    if timestamp < 3600:
+        return f"{int(timestamp / 60)} min ago"
+    if timestamp < 3600 * 24:
+        hours = int(timestamp / 3600)
+        if hours == 1:
+            return "1 hour ago"
+        return f"{hours} hours ago"
+    return f"updated on {datetime}"
+
+
 def check_syntax(output_settings: Union[Tuple[str], List[str]], length: int):
     """Check syntax of output_settings.
 

--- a/tactus/reference_checker.py
+++ b/tactus/reference_checker.py
@@ -14,6 +14,8 @@ from tactus.logs import logger
 from tactus.os_utils import FileLock, Search, tactusmakedirs
 from tactus.toolbox import FileManager, Platform
 
+from .datetime_utils import since_str
+
 
 class ReferenceChecker:
     """Base class for comparison against a reference."""
@@ -516,23 +518,34 @@ class CheckSummaryAnalysis:
         """Increment generated_count."""
         self.generated_count = self.generated_count + 1
 
+    def append_error_message(self, error_message):
+        """Append an error message."""
+        if len(self.error_message) == 0:
+            self.error_message = error_message
+        else:
+            self.error_message = f"{self.error_message}\n{error_message}"
+
     def success(self):
         """Return true iff all the tests are successful."""
+        if len(self.error_message) > 0:
+            return False
+
         if not self.check:
             return True
 
-        return (
-            self.error_count == 0 and self.missing_count == 0 and self.success_count > 0
-        )
+        return self.error_count == 0 and self.missing_count == 0
 
     def total_count(self):
         """Retern total number of files tested and missing."""
         return self.error_count + self.success_count + self.missing_count
 
     def message(self):
-        """Retern a summary message."""
+        """Return a summary message."""
+        if len(self.error_message) > 0:
+            return f"ERROR : {self.error_message}"
+
         if not self.check:
-            result_message = "N/A - check is disabled"
+            result_message = "MISSING - check is disabled"
             if self.missing_count > 0:
                 result_message = f"{result_message}. {self.missing_count} missing(s)"
             return result_message
@@ -542,6 +555,79 @@ class CheckSummaryAnalysis:
             f"{result_message} - {self.error_count} error(s),"
             + f" {self.success_count} success(es), {self.missing_count} missing(s)"
         )
+
+    @staticmethod
+    def colored_result_message(
+        summary, verbose, case_name, filename, width, datetime, now
+    ):
+        """Return a colored message summarizing the result of the analysis.
+
+        Args:
+            summary: the summary analysis containing the result of the analysis
+            verbose: boolean indicating if the message should contain details
+            case_name: the name of the case being analyzed
+            filename: the name of the summary file being analyzed
+            width: the width to be used for the case name in the message
+            datetime: the datetime of the summary file being analyzed
+            now: the current datetime
+
+        Returns:
+            A colored message summarizing the result of the analysis
+        """
+        message = ""
+        color = "cyan"
+
+        if not summary:
+            return f"{case_name:<{width}} |<{color}> MISSING</{color}>"
+        since = since_str(datetime, now)
+        if "analysis" not in summary:
+            color = "yellow"
+            message = f"{case_name:<{width}} |<{color}> RUNNING</{color}> ({since})"
+
+        else:
+            color = "green"
+            if summary["analysis"]["missing_count"] > 0:
+                color = "red"
+            if summary["analysis"]["error_count"] > 0:
+                color = "red"
+            result = summary["analysis"]["result"].split("-")
+            result[1] = result[1].strip()
+            message = (
+                f"{case_name:<{width}} | <{color}>{result[0]}</{color}>({since})"
+                + f" <white>[{result[1]}]</white>"
+            )
+
+        if verbose:
+            message += "\n"
+            message += f"{'from':>10} | {filename}\n"
+            if "analysis" not in summary:
+                message += (
+                    f"{'Unknown':>10} | <{color}>Test is still running"
+                    + f" or has failed. </{color}> \n"
+                )
+            else:
+                for results in summary["tasks"].values():
+                    for test_type, result in results.items():
+                        if test_type == "Create":
+                            continue
+                        try:
+                            result_message = (
+                                f"{test_type:>10} | {result['items'][0]['result']}"
+                            )
+                            result_message = result_message.replace("\n", "")
+                            result_message = result_message.replace(
+                                "SUCCESS", "<green>SUCCESS</green>"
+                            )
+                            result_message = result_message.replace(
+                                "FAILURE", "<red>FAILURE</red>"
+                            )
+
+                            message = f"{message}{result_message}\n"
+                        except KeyError:
+                            message += f"{test_type:>10} |\
+                                {result['items'][0]['warning']}"
+
+        return message
 
 
 class CheckSummaryTxt(CheckSummary):
@@ -578,7 +664,7 @@ class CheckSummaryTxt(CheckSummary):
                 summary_file.write(f"#   {label}:{git_info[label]}\n")
             summary_file.write("\n")
             summary_file.write("-\n")
-            summary_file.write("Task: Prep\n")
+            summary_file.write("Task: Preparation\n")
             summary_file.write("Rule: Create\n")
             summary_file.write(f"Description: Creation of {self.fullpath}\n")
             summary_file.write("\n")
@@ -657,6 +743,10 @@ class CheckSummaryTxt(CheckSummary):
                             analysis.increment_generated_count()
 
             with open(self.fullpath, mode="a", encoding="utf8") as outfile:
+                outfile.write("\n")
+                outfile.write("-\n")
+                outfile.write("Task: ReferenceChecker\n")
+                outfile.write("Rule: Create Summary\n")
                 outfile.write(f"# Generated files: {analysis.generated_count}\n")
                 outfile.write(f"# Successful tests: {analysis.success_count}\n")
                 outfile.write(f"# Failure tests: {analysis.error_count}\n")
@@ -664,6 +754,7 @@ class CheckSummaryTxt(CheckSummary):
                 outfile.write(f"# Total files: {analysis.total_count()}\n")
                 outfile.write(f"# Success: {analysis.success()}\n")
                 outfile.write(f"# Result: {analysis.message()}\n")
+                outfile.write("\n")
 
         return analysis
 

--- a/tactus/reference_checker.py
+++ b/tactus/reference_checker.py
@@ -578,7 +578,7 @@ class CheckSummaryAnalysis:
         message = ""
         color = "cyan"
 
-        if isinstance(summary,str):
+        if isinstance(summary, str):
             return f"{case_name:<{width}} |<{color}> {summary}</{color}>"
 
         since = since_str(datetime, now)

--- a/tactus/reference_checker.py
+++ b/tactus/reference_checker.py
@@ -501,6 +501,7 @@ class CheckSummaryAnalysis:
         self.missing_count = 0
         self.generated_count = 0
         self.check = check
+        self.error_message = ""
 
     def increment_error_count(self):
         """Increment error_count."""

--- a/tactus/reference_checker.py
+++ b/tactus/reference_checker.py
@@ -578,8 +578,9 @@ class CheckSummaryAnalysis:
         message = ""
         color = "cyan"
 
-        if not summary:
-            return f"{case_name:<{width}} |<{color}> MISSING</{color}>"
+        if isinstance(summary,str):
+            return f"{case_name:<{width}} |<{color}> {summary}</{color}>"
+
         since = since_str(datetime, now)
         if "analysis" not in summary:
             color = "yellow"

--- a/tactus/test_runner.py
+++ b/tactus/test_runner.py
@@ -46,6 +46,7 @@ class TestCases:
         if args.config_file is not None:
             logger.info("Using config file: {}", args.config_file)
             self.config = ParsedConfig.from_file(args.config_file, json_schema={})
+            self.config_name = Path(args.config_file).resolve().stem
             try:
                 definitions = self.config.expand_macros().dict()
             except KeyError:
@@ -281,7 +282,7 @@ class TestCases:
         from .__main__ import main as tactus_main
 
         try:
-            with open(f"{self.test_dir}/config_names.toml", "rb") as f:
+            with open(f"{self.test_dir}/{self.config_name}_config_names.toml", "rb") as f:
                 config_names = tomli.load(f)
         except FileNotFoundError as err:
             msg = "No case mapping available. Run again without '-r'"
@@ -565,7 +566,7 @@ class TestCases:
                         for c, item in self.cases.items()
                         if "config_name" in item
                     }
-                }).save_as(f"{directory}/config_names.toml")
+                }).save_as(f"{directory}/{self.config_name}_config_names.toml")
 
             if not args.run:
                 logger.info("\n\nRerun with '-r' to start the suites\n\n")

--- a/tactus/test_runner.py
+++ b/tactus/test_runner.py
@@ -5,6 +5,7 @@ import concurrent.futures
 import contextlib
 import copy
 import glob
+import json
 import os
 import shutil
 import tempfile
@@ -22,6 +23,7 @@ from .general_utils import merge_dicts
 from .host_actions import TactusHost
 from .logs import logger
 from .reference_checker import CheckSummaryAnalysis
+from .toolbox import Platform
 
 
 class TestCases:
@@ -593,7 +595,7 @@ def run_test(args, config=None):
 
     elif args.config_file is not None:
         if args.configure or args.run:
-        t.execute(args)
+            t.execute(args)
         else:
             t.collect_summaries()
 

--- a/tactus/test_runner.py
+++ b/tactus/test_runner.py
@@ -477,7 +477,9 @@ class TestCases:
             validtime=case_config["general.times.start"],
         )
         references_folder = platform.get_platform_value("references_folder")
-        return case_name, json_file, references_folder
+        check = case_config["reference_checker"]["check"]
+
+        return check, case_name, json_file, references_folder
 
     def collect_summaries(self):
         """Collect summaries from the runs."""
@@ -498,21 +500,26 @@ class TestCases:
         case_files = {}
         width = 0
         now = datetime.now()
+        skipped = set()
         for config_file in config_files:
-            case_name, json_file, references_folder = TestCases.get_case_information(
-                config_file
+            check, case_name, json_file, references_folder = (
+                TestCases.get_case_information(config_file)
             )
-            case_files[case_name] = json_file
-            try:
-                with open(json_file, "r", encoding="utf-8") as f:
-                    summary = json.load(f)
-                    summary["creation_date"] = datetime.fromtimestamp(
-                        os.path.getmtime(json_file)
-                    )
-            except FileNotFoundError:
-                summary = None
+            if check:
+                case_files[case_name] = json_file
+                try:
+                    with open(json_file, "r", encoding="utf-8") as f:
+                        summary = json.load(f)
+                        summary["creation_date"] = datetime.fromtimestamp(
+                            os.path.getmtime(json_file)
+                        )
+                except FileNotFoundError:
+                    summary = "MISSING"
 
-            summaries[case_name] = summary
+                summaries[case_name] = summary
+            else:
+                summaries[case_name] = "SKIPPED"
+                skipped.add(case_name)
             width = max(width, len(case_name))
 
         if len(summaries) > 0:
@@ -521,13 +528,17 @@ class TestCases:
             with contextlib.suppress(KeyError):
                 logger.info(" from {}", self.ial["pr"])
             logger.info("Comparison against {}", references_folder)
-            for case_name, summary in sorted(summaries.items()):
-                creation_date = summary["creation_date"] if summary else None
+
+            case_names = sorted([x for x in summaries if x in skipped])
+            case_names.extend(sorted([x for x in summaries if x not in skipped]))
+            for case_name in case_names:
+                summary = summaries[case_name]
+                creation_date = summary["creation_date"] if not isinstance(summary,str) else None
                 colored_message = CheckSummaryAnalysis.colored_result_message(
                     summary,
                     self.verbose,
                     case_name,
-                    case_files[case_name],
+                    case_files[case_name] if case_name in case_files else None,
                     width,
                     creation_date,
                     now,

--- a/tactus/test_runner.py
+++ b/tactus/test_runner.py
@@ -8,6 +8,7 @@ import glob
 import os
 import shutil
 import tempfile
+from datetime import datetime
 from pathlib import Path
 
 import tomli
@@ -20,6 +21,7 @@ from .fullpos import flatten_list
 from .general_utils import merge_dicts
 from .host_actions import TactusHost
 from .logs import logger
+from .reference_checker import CheckSummaryAnalysis
 
 
 class TestCases:
@@ -446,6 +448,92 @@ class TestCases:
                 self.cases[case]["hostname"] = hostnames[item["host"]]["config_name"]
                 self.cases[case]["hostdomain"] = hostnames[item["host"]]["domain_name"]
 
+    @staticmethod
+    def get_case_information(config_file):
+        """Get case name, json file and reference folder from the config file.
+
+        Arguments:
+            config_file (str): Path to the config file
+
+        Returns:
+            case_name name: the name of the case.
+            json_file: the json file path
+            references_folder: the references folder path.
+        """
+        case_config = ParsedConfig.from_file(config_file, json_schema={})
+        platform = Platform(case_config)
+
+        case_name = platform.substitute(
+            case_config.get("general.case"),
+            basetime=case_config["general.times.start"],
+            validtime=case_config["general.times.start"],
+        )
+        json_file = platform.substitute(
+            case_config.get("reference_checker.summary.json.file"),
+            basetime=case_config["general.times.start"],
+            validtime=case_config["general.times.start"],
+        )
+        references_folder = platform.get_platform_value("references_folder")
+        return case_name, json_file, references_folder
+
+    def collect_summaries(self):
+        """Collect summaries from the runs."""
+        try:
+            with open(f"{self.test_dir}/{self.config_name}_config_names.toml", "rb") as f:
+                config_names = tomli.load(f)
+        except FileNotFoundError as err:
+            msg = "No case mapping available. Run again with '-m'"
+            logger.error(msg)
+            raise FileNotFoundError(msg) from err
+
+        config_files = [
+            f"{self.test_dir}/{config_name}.toml"
+            for config_name in config_names["config_names"].values()
+        ]
+
+        summaries = {}
+        case_files = {}
+        width = 0
+        now = datetime.now()
+        for config_file in config_files:
+            case_name, json_file, references_folder = TestCases.get_case_information(
+                config_file
+            )
+            case_files[case_name] = json_file
+            try:
+                with open(json_file, "r", encoding="utf-8") as f:
+                    summary = json.load(f)
+                    summary["creation_date"] = datetime.fromtimestamp(
+                        os.path.getmtime(json_file)
+                    )
+            except FileNotFoundError:
+                summary = None
+
+            summaries[case_name] = summary
+            width = max(width, len(case_name))
+
+        if len(summaries) > 0:
+            with contextlib.suppress(KeyError):
+                logger.info("Our version {}", self.ial["ial_hash"])
+            with contextlib.suppress(KeyError):
+                logger.info(" from {}", self.ial["pr"])
+            logger.info("Comparison against {}", references_folder)
+            for case_name, summary in sorted(summaries.items()):
+                creation_date = summary["creation_date"] if summary else None
+                colored_message = CheckSummaryAnalysis.colored_result_message(
+                    summary,
+                    self.verbose,
+                    case_name,
+                    case_files[case_name],
+                    width,
+                    creation_date,
+                    now,
+                )
+                logger.opt(colors=True).info(colored_message)
+
+            if not self.verbose:
+                logger.opt(colors=True).info("<blue>Add '-v' for more info</blue>")
+
     def execute(self, args):
         """Execute test cases.
 
@@ -494,6 +582,9 @@ def run_test(args, config=None):
     """
     t = TestCases(args=args)
 
+    if not args.config_file and not args.prepare_binaries and not args.list:
+        logger.warning("Nothing to do. Use `tactus test -h` for help.")
+        return False
     if args.prepare_binaries:
         t.get_binaries()
 
@@ -501,4 +592,9 @@ def run_test(args, config=None):
         t.list()
 
     elif args.config_file is not None:
+        if args.configure or args.run:
         t.execute(args)
+        else:
+            t.collect_summaries()
+
+    return True

--- a/tactus/test_runner.py
+++ b/tactus/test_runner.py
@@ -533,12 +533,14 @@ class TestCases:
             case_names.extend(sorted([x for x in summaries if x not in skipped]))
             for case_name in case_names:
                 summary = summaries[case_name]
-                creation_date = summary["creation_date"] if not isinstance(summary,str) else None
+                creation_date = (
+                    summary["creation_date"] if not isinstance(summary, str) else None
+                )
                 colored_message = CheckSummaryAnalysis.colored_result_message(
                     summary,
                     self.verbose,
                     case_name,
-                    case_files[case_name] if case_name in case_files else None,
+                    case_files.get(case_name) if case_name in case_files else None,
                     width,
                     creation_date,
                     now,

--- a/tests/unit/test_datetime_utils.py
+++ b/tests/unit/test_datetime_utils.py
@@ -19,6 +19,7 @@ from tactus.datetime_utils import (
     get_decade,
     get_month_list,
     oi2dt_list,
+    since_str,
 )
 
 
@@ -297,3 +298,28 @@ def test_check_syntax_valid(output_settings: List[str], length: int):
         check_syntax(output_settings, length)
     except SystemExit:
         pytest.fail("check_syntax raised SystemExit unexpectedly!")
+
+
+def test_since_str():
+    """Test that since_str returns the expected string representation of the timestamp."""
+    expected_results = {
+        0: "Now",
+        1: "Now",
+        59: "Now",
+        60: "1 min ago",
+        90: "1 min ago",
+        180: "3 min ago",
+        3600: "1 hour ago",
+        12000: "3 hours ago",
+        86399: "23 hours ago",
+        86400: "set_dynamically",
+        186412: "set_dynamically",
+        991261: "set_dynamically",
+    }
+
+    for time in expected_results:
+        now_date = datetime.datetime(2026, 6, 1, 0, 0, 0)
+        creation_date = now_date - datetime.timedelta(seconds=time)
+        if expected_results[time] == "set_dynamically":
+            expected_results[time] = f"updated on {creation_date}"
+        assert since_str(creation_date, now_date) == expected_results[time]

--- a/tests/unit/test_reference_checker.py
+++ b/tests/unit/test_reference_checker.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Unit tests for reference_checker.py."""
 
+import datetime
 import json
 import os
 import shutil
@@ -12,6 +13,7 @@ import tomlkit
 from tactus.derived_variables import set_times
 from tactus.reference_checker import (
     CheckSummary,
+    CheckSummaryAnalysis,
     CheckSummaryJson,
     CheckSummaryTxt,
     NormsChecker,
@@ -552,7 +554,7 @@ class TestReferenceCheckManager:
                 self.total_failure_count + self.count[method]["failure"]
             )
         if not self.check:
-            result_message = "N/A - check is disabled"
+            result_message = "MISSING - check is disabled"
             if self.missing_file_count > 0:
                 result_message = f"{result_message}. {self.missing_file_count} missing(s)"
             self.analysis_result = result_message
@@ -645,23 +647,23 @@ class TestReferenceCheckManager:
         total_count = (
             self.total_success_count + self.missing_file_count + self.total_failure_count
         )
-        expecteds = {}
-        expecteds["# Generated files:"] = str(self.generated_file_count)
-        expecteds["# Successful tests:"] = str(self.total_success_count)
-        expecteds["# Failure tests:"] = str(self.total_failure_count)
-        expecteds["# Missing files:"] = str(self.missing_file_count)
-        expecteds["# Total files:"] = str(total_count)
-        expecteds["# Success:"] = str(self.expected_success)
-        expecteds["# Result:"] = str(self.analysis_result)
+        expected_list = {}
+        expected_list["# Generated files:"] = str(self.generated_file_count)
+        expected_list["# Successful tests:"] = str(self.total_success_count)
+        expected_list["# Failure tests:"] = str(self.total_failure_count)
+        expected_list["# Missing files:"] = str(self.missing_file_count)
+        expected_list["# Total files:"] = str(total_count)
+        expected_list["# Success:"] = str(self.expected_success)
+        expected_list["# Result:"] = str(self.analysis_result)
 
         with open(summary_txt_path, "r") as file:
             lines = file.readlines()
 
         # the number of lines written in the last part of the summary
-        lines_in_analysis = 7
+        lines_in_analysis = 8
         assert len(lines) > lines_in_analysis
 
-        for key, expected in expecteds.items():
+        for key, expected in expected_list.items():
             found = False
             for line in lines[-lines_in_analysis:]:
                 if line.startswith(key):
@@ -696,6 +698,54 @@ class TestReferenceCheckManager:
             assert data["analysis"]["generated_count"] == self.generated_file_count
             assert data["analysis"]["total_count"] == total_count
             assert data["analysis"]["result"] == self.analysis_result
+
+    def _validate_colored_result_message(self, summary_json_path, case_name):
+        """Validation of the colored results message in the summary.
+
+        Args:
+            summary_json_path: the file path to the json summary
+            case_name: the name of the test case
+        """
+        with open(summary_json_path, "r") as file:
+            summary = json.load(file)
+
+        time = 130  # seconds
+        now = datetime.datetime.now()
+        creation_date = datetime.datetime.now() - datetime.timedelta(seconds=time)
+        assert summary
+        colored_message = CheckSummaryAnalysis.colored_result_message(
+            summary,
+            False,
+            case_name,
+            summary_json_path,
+            len(case_name),
+            creation_date,
+            now,
+        )
+        expected = {}
+        for test in [
+            "check_identical",
+            "check_smalldiff",
+            "check_diff",
+            "check_diff_suppress_exception",
+            "check_identical_generate",
+            "check_generate_nofile",
+        ]:
+            expected[test] = f"{test} | "
+            if self.expected_success:
+                expected[test] += "<green>SUCCESS </green>"
+            else:
+                expected[test] += "<red>FAILURE </red>"
+            expected[test] += "(2 min ago) "
+            expected[test] += (
+                f"<white>[{self.total_failure_count} error(s), {self.total_success_count} success(es), {self.missing_file_count} missing(s)]</white>"
+            )
+
+        expected["generate"] = (
+            "generate | <green>MISSING </green>(2 min ago) <white>[check is disabled]</white>"
+        )
+
+        assert colored_message == expected[case_name]
 
     def _simulate_suite_execution(self, basic_config, test_combination):
         """Simulate the execution of a suite.
@@ -775,6 +825,9 @@ class TestReferenceCheckManager:
 
             self._validate_txt_analysis_content(summary_txt_path)
             self._validate_json_analysis_content(summary_json_path)
+
+            self._validate_colored_result_message(summary_json_path, test_combination)
+
             return True
 
         assert not os.path.exists(summary_txt_path)


### PR DESCRIPTION
## Describe your changes

This PR adds the functionality to display a summary of all the tests performed with tactus test runner.

This is run by launching the 'tactus test -c config.toml', without argument (ie no `-r` and no `-m`).


Here is an example for CY50:

```
$ tactus test -c tactus/data/tests/atos_bologna_CY50t2.toml  
[..]
2026-06-12 15:01:31 | INFO     |  tag: feature_activate_reference_checker_
2026-06-12 15:01:31 | INFO     |  test_dir: feature_activate_reference_checker_configs
2026-06-12 15:01:31 | INFO     | Comparison against /scratch/cvap/tactus_references/v1.1.0
2026-06-12 15:23:25 | INFO     | feature_activate_reference_checker_intel_CY50t2_compile                                                    | MISSING
2026-06-12 15:23:25 | INFO     | feature_activate_reference_checker_intel_R64_CY50t2_ALARO_DEMO_60x80_2500m_20250209                        | FAILURE (1 hour ago) [1 error(s), 2 success(es), 0 missing(s)]
2026-06-12 15:23:25 | INFO     | feature_activate_reference_checker_intel_R64_CY50t2_ALARO_DEMO_60x80_2500m_20250209_climate_files          | SUCCESS (1 hour ago) [0 error(s), 0 success(es), 0 missing(s)]
2026-06-12 15:23:25 | INFO     | feature_activate_reference_checker_intel_R64_CY50t2_ALARO_DEMO_60x80_2500m_20250209_ddh                    | MISSING
2026-06-12 15:23:25 | INFO     | feature_activate_reference_checker_intel_R64_CY50t2_ALARO_DEMO_60x80_2500m_20250209_eps                    | MISSING
2026-06-12 15:23:25 | INFO     | feature_activate_reference_checker_intel_R64_CY50t2_ALARO_DEMO_60x80_2500m_20250209_mode_start             | FAILURE (4 hours ago) [1 error(s), 2 success(es), 0 missing(s)]
2026-06-12 15:23:25 | INFO     | feature_activate_reference_checker_intel_R64_CY50t2_AROME_DEMO_60x80_2500m_20250209                        | FAILURE (4 hours ago) [1 error(s), 4 success(es), 0 missing(s)]
2026-06-12 15:23:25 | INFO     | feature_activate_reference_checker_intel_R64_CY50t2_AROME_DEMO_60x80_2500m_20250209_climate_files          | SUCCESS (4 hours ago) [0 error(s), 0 success(es), 0 missing(s)]
2026-06-12 15:23:25 | INFO     | feature_activate_reference_checker_intel_R64_CY50t2_AROME_DEMO_60x80_2500m_20250209_ddh                    | MISSING
2026-06-12 15:23:25 | INFO     | feature_activate_reference_checker_intel_R64_CY50t2_AROME_DEMO_60x80_2500m_20250209_eps                    | RUNNING (4 hours ago)
2026-06-12 15:23:25 | INFO     | feature_activate_reference_checker_intel_R64_CY50t2_AROME_DEMO_60x80_2500m_20250209_mode_start             | FAILURE (4 hours ago) [1 error(s), 4 success(es), 0 missing(s)]
2026-06-12 15:23:25 | INFO     | feature_activate_reference_checker_intel_R64_CY50t2_AROME_DEMO_80x90_1000m_20250209                        | MISSING
2026-06-12 15:23:25 | INFO     | feature_activate_reference_checker_intel_R64_CY50t2_HARMONIE_AROME_DEMO_60x80_2500m_20250209               | SUCCESS (4 hours ago) [0 error(s), 5 success(es), 0 missing(s)]
2026-06-12 15:23:25 | INFO     | feature_activate_reference_checker_intel_R64_CY50t2_HARMONIE_AROME_DEMO_60x80_2500m_20250209_climate_files | SUCCESS (4 hours ago) [0 error(s), 0 success(es), 0 missing(s)]
2026-06-12 15:23:25 | INFO     | feature_activate_reference_checker_intel_R64_CY50t2_HARMONIE_AROME_DEMO_60x80_2500m_20250209_ddh           | SUCCESS (4 hours ago) [0 error(s), 5 success(es), 0 missing(s)]
2026-06-12 15:23:25 | INFO     | feature_activate_reference_checker_intel_R64_CY50t2_HARMONIE_AROME_DEMO_60x80_2500m_20250209_eps           | RUNNING (4 hours ago)
2026-06-12 15:23:25 | INFO     | feature_activate_reference_checker_intel_R64_CY50t2_HARMONIE_AROME_DEMO_60x80_2500m_20250209_mode_start    | SUCCESS (4 hours ago) [0 error(s), 5 success(es), 0 missing(s)]
2026-06-12 15:23:25 | INFO     | feature_activate_reference_checker_intel_R64_CY50t2_HARMONIE_AROME_DEMO_80x90_1000m_20250209               | SUCCESS (3 hours ago) [0 error(s), 5 success(es), 0 missing(s)]
2026-06-12 15:01:31 | INFO     |  add '-v' for more info
2026-06-12 15:01:31 | INFO     | Leaving tactus v1.0.0 --> "tactus test -c tactus/data/tests/atos_bologna_CY50t2.toml". Total runtime: 1.10s.
```

We also rename the config_names.toml file to {self.config_name}_config_names.toml to allow to run several tests in the same folder:
$ tactus test -c tactus/data/tests/atos_bologna_CY49t2.toml -m 
$ tactus test -c tactus/data/tests/atos_bologna_CY50t2.toml -m 

Note: This PR has been extracted from #111

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

### Testing

- [ ] I have tested this on ATOS using the `atos_bologna.toml` configuration in the latest version of [Tactus-test-runner](https://github.com/destination-earth-digital-twins/Tactus-test-runner)
- [ ] I have tested this on LUMI using the `lumi.toml` configuration in the latest version of [Tactus-test-runner](https://github.com/destination-earth-digital-twins/Tactus-test-runner)

For further information see the [development guide](https://github.com/ACCORD-NWP/tactus/blob/develop/docs/markdown_docs/development_guide.md)

### Code quality

- [ ] My change follows the [best practices for this project](https://github.com/ACCORD-NWP/tactus/blob/develop/docs/markdown_docs/development_guide.md#best-practices).
- [ ] My local environment is correctly initialised as described in the [README](https://github.com/ACCORD-NWP/tactus/blob/develop/README.md) file.
- [ ] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation and docstrings to reflect the changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have ensured that the code is still installable with `poetry` after the changes and runs
- [ ] I have requested one or more reviewer(s) and an assignee (assignee is responsible for merging). At least one reviewer has accepted to review.

## Checklist for reviewers
Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code readable
- [ ] the code well tested (checked coverage report)
- [ ] the code documented
- [ ] the code easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change (in section
  reflecting type of change, for example "bug fixes", add section where
  missing)

## Checklist for assignees
- [ ] PR is up to date with the base branch
- [ ] the tests passing
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- [ ] the PR has been approved by all the reviewers, that accepted to review.
- Once the PR ready to be merged, squash commits and merge the PR.

## Tag possible reviewers
You can @-tag people to review this PR in addition to formal review requests.
@kastelecn @pardallio @uandrae 