### PR TITLE
Unit test: reference_checker:  create test data in tmp instead of scratch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/destination-earth-digital-twins/Deode-Prototype/tree/HEAD)
 
-- Tactus test runner - Fix underscore in test definition. [#127](https://github.com/ACCORD-NWP/tactus/pull/127) (@dhaumont)
-- ALARO: Use APL_ALARO routines instead of APLPAR. [#135](https://github.com/ACCORD-NWP/tactus/pull/135) (@dhaumont)
-- Test runner - display summary of all tests. [#129](https://github.com/ACCORD-NWP/tactus/pull/129/)(@dhaumont)
-- ReferenceChecker: Improve the way the summary are created. [#128](https://github.com/ACCORD-NWP/tactus/pull/128/)(@dhaumont)
-- Tactus test runner - activate reference checker. [#130](https://github.com/ACCORD-NWP/tactus/pull/130) (@dhaumont)
 - Unit test: reference_checker: create test data in tmp instead of scratch [#140](https://github.com/ACCORD-NWP/tactus/pull/140) (@dhaumont)
+- Tactus test runner - activate reference checker. [#130](https://github.com/ACCORD-NWP/tactus/pull/130) (@dhaumont)
+- ReferenceChecker: Improve the way the summary are created. [#128](https://github.com/ACCORD-NWP/tactus/pull/128/)(@dhaumont)
+- Test runner - display summary of all tests. [#129](https://github.com/ACCORD-NWP/tactus/pull/129/)(@dhaumont)
+- ALARO: Use APL_ALARO routines instead of APLPAR. [#135](https://github.com/ACCORD-NWP/tactus/pull/135) (@dhaumont)
+- Tactus test runner - Fix underscore in test definition. [#127](https://github.com/ACCORD-NWP/tactus/pull/127) (@dhaumont)
 
 ## [1.2.0] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Test runner - display summary of all tests. [#129](https://github.com/ACCORD-NWP/tactus/pull/129/)(@dhaumont)
 - ReferenceChecker: Improve the way the summary are created. [#128](https://github.com/ACCORD-NWP/tactus/pull/128/)(@dhaumont)
 - Tactus test runner - activate reference checker. [#130](https://github.com/ACCORD-NWP/tactus/pull/130) (@dhaumont)
+- Unit test: reference_checker: create test data in tmp instead of scratch [#140](https://github.com/ACCORD-NWP/tactus/pull/140) (@dhaumont)
 
 ### Changed
 - Let the DKCOEXP be the default large domain. [\#116](https://github.com/ACCORD-NWP/tactus/pull/116)(@uandrae)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/destination-earth-digital-twins/Deode-Prototype/tree/HEAD)
 
-## [1.2.0] - 2026-06-18
-
-### Added
-- Introduce CY50t2 test cases in the test-runner. [\#88](https://github.com/ACCORD-NWP/tactus/pull/88) (@uandrae)
-- Added suite control switch for grib calculations. [#102](https://github.com/ACCORD-NWP/tactus/pull/102) (@uandrae)
-- Introduce perturbation family and config section. [#87](https://github.com/ACCORD-NWP/tactus/pull/87) (@uandrae)
 - Tactus test runner - Fix underscore in test definition. [#127](https://github.com/ACCORD-NWP/tactus/pull/127) (@dhaumont)
 - ALARO: Use APL_ALARO routines instead of APLPAR. [#135](https://github.com/ACCORD-NWP/tactus/pull/135) (@dhaumont)
 - Test runner - display summary of all tests. [#129](https://github.com/ACCORD-NWP/tactus/pull/129/)(@dhaumont)
 - ReferenceChecker: Improve the way the summary are created. [#128](https://github.com/ACCORD-NWP/tactus/pull/128/)(@dhaumont)
 - Tactus test runner - activate reference checker. [#130](https://github.com/ACCORD-NWP/tactus/pull/130) (@dhaumont)
 - Unit test: reference_checker: create test data in tmp instead of scratch [#140](https://github.com/ACCORD-NWP/tactus/pull/140) (@dhaumont)
+
+## [1.2.0] - 2026-06-18
+
+### Added
+- Introduce CY50t2 test cases in the test-runner. [\#88](https://github.com/ACCORD-NWP/tactus/pull/88) (@uandrae)
+- Added suite control switch for grib calculations. [#102](https://github.com/ACCORD-NWP/tactus/pull/102) (@uandrae)
+- Introduce perturbation family and config section. [#87](https://github.com/ACCORD-NWP/tactus/pull/87) (@uandrae)
 
 ### Changed
 - Let the DKCOEXP be the default large domain. [\#116](https://github.com/ACCORD-NWP/tactus/pull/116)(@uandrae)

--- a/tests/unit/test_reference_checker.py
+++ b/tests/unit/test_reference_checker.py
@@ -25,7 +25,8 @@ from tactus.toolbox import FileManager
 
 
 @pytest.fixture(scope="module")
-def basic_config(default_config):
+def basic_config(tmp_directory,default_config):
+    scratch = tmp_directory
     config = default_config
     config = config.copy(update=set_times(config))
     return config.copy(
@@ -33,6 +34,9 @@ def basic_config(default_config):
             "general": {
                 "cycle": "CY49t2",
                 "case": "@CASE_PREFIX@@CYCLE@_@CSC@_nwp_@DOMAIN@_@YMD_START@",
+            },
+            "platform":{
+                "scratch" : scratch
             }
         }
     )

--- a/tests/unit/test_reference_checker.py
+++ b/tests/unit/test_reference_checker.py
@@ -25,7 +25,7 @@ from tactus.toolbox import FileManager
 
 
 @pytest.fixture(scope="module")
-def basic_config(tmp_directory,default_config):
+def basic_config(tmp_directory, default_config):
     scratch = tmp_directory
     config = default_config
     config = config.copy(update=set_times(config))
@@ -35,9 +35,7 @@ def basic_config(tmp_directory,default_config):
                 "cycle": "CY49t2",
                 "case": "@CASE_PREFIX@@CYCLE@_@CSC@_nwp_@DOMAIN@_@YMD_START@",
             },
-            "platform":{
-                "scratch" : scratch
-            }
+            "platform": {"scratch": scratch},
         }
     )
 


### PR DESCRIPTION
## Describe your changes
Bug fix for #38 

The test data were moved to tmp directory instead of $SCRATCH


## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

