### PR TITLE
Make ParsedConfig uniform in docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/destination-earth-digital-twins/Deode-Prototype/tree/HEAD)
 
 ### Added
+- Make ParsedConfig uniform in docstring. [#161](https://github.com/ACCORD-NWP/tactus/pull/161)(@dhaumont)
 - Tactus test runner - introduce several new reference checks. [#150](https://github.com/ACCORD-NWP/tactus/pull/150) (@uandrae)
 - Add `tactus compile` subcommand for IAL compilation configurations, including the `cy50t2_compile` preset, `@IAL_TAG@` macro, and supporting documentation. [#132](https://github.com/ACCORD-NWP/tactus/pull/132) (@pardallio)
 - Unit test: reference_checker: create test data in tmp instead of scratch [#140](https://github.com/ACCORD-NWP/tactus/pull/140) (@dhaumont)
@@ -18,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Test runner - display summary of all tests. [#129](https://github.com/ACCORD-NWP/tactus/pull/129/)(@dhaumont)
 - ALARO: Use APL_ALARO routines instead of APLPAR. [#135](https://github.com/ACCORD-NWP/tactus/pull/135) (@dhaumont)
 - Tactus test runner - Fix underscore in test definition. [#127](https://github.com/ACCORD-NWP/tactus/pull/127) (@dhaumont)
-- Make ParsedConfig uniform in docstring. [#161](https://github.com/ACCORD-NWP/tactus/pull/161)(@dhaumont)
 
 ### Changed
 - Update CY50t2 namelists for Harmonie-Arome CSC. [#115](https://github.com/ACCORD-NWP/tactus/pull/115) (@romick-knmi, @uandrae)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Test runner - display summary of all tests. [#129](https://github.com/ACCORD-NWP/tactus/pull/129/)(@dhaumont)
 - ALARO: Use APL_ALARO routines instead of APLPAR. [#135](https://github.com/ACCORD-NWP/tactus/pull/135) (@dhaumont)
 - Tactus test runner - Fix underscore in test definition. [#127](https://github.com/ACCORD-NWP/tactus/pull/127) (@dhaumont)
+- Make ParsedConfig uniform in docstring. [#161](https://github.com/ACCORD-NWP/tactus/pull/161)(@dhaumont)
 
 ### Changed
 - Update CY50t2 namelists for Harmonie-Arome CSC. [#115](https://github.com/ACCORD-NWP/tactus/pull/115) (@romick-knmi, @uandrae)

--- a/tactus/boundary_utils.py
+++ b/tactus/boundary_utils.py
@@ -14,7 +14,7 @@ class Boundary:
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         platform = Platform(config)
 

--- a/tactus/cleaning.py
+++ b/tactus/cleaning.py
@@ -34,7 +34,7 @@ class CleanTactus:
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
             defaults (dict): Default cleaning settings
             basetime (dateTime object): Reference time
 

--- a/tactus/commands_functions.py
+++ b/tactus/commands_functions.py
@@ -76,7 +76,7 @@ def run_task(args: RunTaskNamespace, config: ParsedConfig):
 
     Args:
         args (argparse.Namespace): Parsed command line arguments.
-        config (.config_parser.ParsedConfig): Parsed config file contents.
+        config (ParsedConfig): Parsed config file contents.
 
     """
     logger.info("Prepare {}...", args.task)
@@ -118,7 +118,7 @@ def create_exp(args, config):
 
     Args:
         args (argparse.Namespace): Parsed command line arguments.
-        config (.config_parser.ParsedConfig): Parsed config file contents.
+        config (ParsedConfig): Parsed config file contents.
 
     """
     known_hosts_file = args.host_file
@@ -156,7 +156,7 @@ def create_compile_exp(args, config):
 
     Args:
         args (argparse.Namespace): Parsed command line arguments.
-        config (.config_parser.ParsedConfig): Parsed config file contents.
+        config (ParsedConfig): Parsed config file contents.
 
     """
     config = config.copy(update={"compile": {"ial_git_branch": args.ial_tag}})
@@ -174,7 +174,7 @@ def start_suite(args, config):
 
     Args:
         args (argparse.Namespace): Parsed command line arguments.
-        config (.config_parser.ParsedConfig): Parsed config file contents.
+        config (ParsedConfig): Parsed config file contents.
 
     Raises:
         SystemExit: If error occurs while transferring files.
@@ -351,7 +351,7 @@ def show_config(args, config):
 
     Args:
         args (argparse.Namespace): Parsed command line arguments.
-        config (.config_parser.ParsedConfig): Parsed config file contents.
+        config (ParsedConfig): Parsed config file contents.
 
     """
     logger.info("Printing requested configs...")
@@ -391,7 +391,7 @@ def show_config_schema(args, config):
 
     Args:
         args (argparse.Namespace): Parsed command line arguments.
-        config (.config_parser.ParsedConfig): Parsed config file contents.
+        config (ParsedConfig): Parsed config file contents.
 
     """
     logger.info("Printing JSON schema used in the validation of the configs...")
@@ -403,7 +403,7 @@ def show_host(args, config):
 
     Args:
         args (argparse.Namespace): Parsed command line arguments.
-        config (.config_parser.ParsedConfig): Parsed config file contents.
+        config (ParsedConfig): Parsed config file contents.
 
     """
     tactus_host = TactusHost()
@@ -521,7 +521,7 @@ def show_namelist(args, config):
 
     Args:
         args (argparse.Namespace): Parsed command line arguments.
-        config (.config_parser.ParsedConfig): Parsed config file contents.
+        config (ParsedConfig): Parsed config file contents.
 
     """
     tactus_home = set_tactus_home(config, args.tactus_home)
@@ -554,7 +554,7 @@ def namelist_integrate(args, config):
 
     Args:
         args (argparse.Namespace): Parsed command line arguments.
-        config (.config_parser.ParsedConfig): Parsed config file contents.
+        config (ParsedConfig): Parsed config file contents.
 
     Raises:
         SystemExit   # noqa: DAR401
@@ -619,7 +619,7 @@ def namelist_convert(args, config: ParsedConfig):
 
     Args:
         args (argparse.Namespace): Parsed command line arguments.
-        config (.config_parser.ParsedConfig): Parsed config file contents.
+        config (ParsedConfig): Parsed config file contents.
 
     """
     # Configuration
@@ -651,7 +651,7 @@ def namelist_format(args, config: ParsedConfig):
 
     Args:
         args (argparse.Namespace): Parsed command line arguments.
-        config (.config_parser.ParsedConfig): Parsed config file contents.
+        config (ParsedConfig): Parsed config file contents.
 
     """
     # Configuration
@@ -678,7 +678,7 @@ def replace_node(args, config):
 
     Args:
         args (argparse.Namespace): Parsed command line arguments.
-        config (.config_parser.ParsedConfig): Parsed config file contents.
+        config (ParsedConfig): Parsed config file contents.
 
     """
     tactus_home = set_tactus_home(config, args.tactus_home)

--- a/tactus/derived_variables.py
+++ b/tactus/derived_variables.py
@@ -15,7 +15,7 @@ def set_times(config):
     """Set basetime/validtime if not present.
 
     Args:
-        config (.config_parser.ParsedConfig): Parsed config file contents.
+        config (ParsedConfig): Parsed config file contents.
 
     Raises:
         ValueError: If start > end
@@ -61,7 +61,7 @@ def check_fullpos_namelist(config, nlgen):
     """Find existing fullpos select files or generate them.
 
     Args:
-        config (tactus.ParsedConfig): Configuration
+        config (ParsedConfig): Configuration
         nlgen (dict): master forecast namelist
 
     Returns:
@@ -113,7 +113,7 @@ def derived_variables(config, processor_layout=None):
     """Derive some variables required in the namelists.
 
     Args:
-        config (tactus.ParsedConfig): Configuration
+        config (ParsedConfig): Configuration
         processor_layout (ProcessorLayout, optional): Processor layout object
 
     Returns:

--- a/tactus/domain_utils.py
+++ b/tactus/domain_utils.py
@@ -7,7 +7,7 @@ def get_domain(config) -> Dict[str, Any]:
     """Read and return domain data.
 
     Args:
-        config (tactus.ParsedConfig): Configuration from which we get the domain data
+        config (ParsedConfig): Configuration from which we get the domain data
     Returns:
         Dictionary containing the domain
     """

--- a/tactus/experiment.py
+++ b/tactus/experiment.py
@@ -38,7 +38,7 @@ class Exp:
         """Instanciate an object of the main experiment class.
 
         Args:
-            config (.config_parser.ParsedConfig): Parsed config file contents.
+            config (ParsedConfig): Parsed config file contents.
             merged_config (dict): Experiment configuration
 
         """
@@ -84,7 +84,7 @@ class ExpFromFiles(Exp):
         """Construct an Exp object from files.
 
         Args:
-            config (.config_parser.ParsedConfig): Parsed config file contents.
+            config (ParsedConfig): Parsed config file contents.
             exp_dependencies (dict): Exp dependencies
             mod_files (List[Path]): Case modifications
             host (TactusHost, optional): tactus host. Defaults to None.
@@ -220,7 +220,7 @@ class EPSExp(Exp):
         """Setup EPS experiment.
 
         Args:
-            config (.config_parser.ParsedConfig): Parsed config file contents.
+            config (ParsedConfig): Parsed config file contents.
         """
         super().__init__(config=config, merged_config=None)
 
@@ -325,7 +325,7 @@ def case_setup(
     """Do experiment setup.
 
     Args:
-        config (.config_parser.ParsedConfig): Parsed config file contents.
+        config (ParsedConfig): Parsed config file contents.
         output_file (str): Output config file.
         mod_files (list): Modifications. Defaults to None.
         case (str, optional): Case identifier. Defaults to None.

--- a/tactus/host_actions.py
+++ b/tactus/host_actions.py
@@ -146,7 +146,7 @@ def set_tactus_home(config, tactus_home=None):
     """Set tactus_home in various ways.
 
     Args:
-        config (.config_parser.ParsedConfig): Parsed config file contents.
+        config (ParsedConfig): Parsed config file contents.
         tactus_home (str): Externally set tactus_home
 
     Returns:

--- a/tactus/initial_conditions.py
+++ b/tactus/initial_conditions.py
@@ -14,7 +14,7 @@ class InitialConditions(object):
         """Construct FirstGuess object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
 
         """
         self.config = config

--- a/tactus/mars_utils.py
+++ b/tactus/mars_utils.py
@@ -33,7 +33,7 @@ def mars_selection(selection: str, config: ParsedConfig) -> dict:
 
     Args:
         selection             (str): The selection to use.
-        config (tactus.ParsedConfig): Configuration object
+        config (ParsedConfig): Configuration object
 
     Returns:
          mars                (dict): mars config section
@@ -306,7 +306,7 @@ def get_domain_data(config):
     """Read and return domain data.
 
     Args:
-        config (tactus.ParsedConfig): Configuration from which we get the domain data
+        config (ParsedConfig): Configuration from which we get the domain data
     Returns:
         String containing the domain info for MARS
     """

--- a/tactus/namelist.py
+++ b/tactus/namelist.py
@@ -144,7 +144,7 @@ class NamelistComparator:
         """Construct the comparator.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
 
         Raises:
             SystemExit
@@ -315,7 +315,7 @@ class NamelistGenerator:
         """Construct the generator.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
             kind (str): one of 'master' or 'surfex'
             substitute (boolean): flag for substitution
 
@@ -664,7 +664,7 @@ class NamelistIntegrator:
         """Construct the integrator.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
 
         Raises:
             SystemExit   # noqa: DAR401

--- a/tactus/reference_checker.py
+++ b/tactus/reference_checker.py
@@ -48,7 +48,7 @@ class ReferenceChecker:
 
         Args:
            method: str defining the method
-           config (tactus.ParsedConfig): Configuration
+           config (ParsedConfig): Configuration
         Returns:
             A ReferenceChecker
         """
@@ -338,7 +338,7 @@ class CheckDefinition:
         """Create the list of items to be checked.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
             taskname: the name of the task
             label_suffix: the suffix for the label
             rules_active: list of rules that are active
@@ -475,7 +475,7 @@ class CheckSummary:
         """Create the list of summary_list from the configuration.
 
         Args:
-           config (tactus.ParsedConfig): Configuration
+           config (ParsedConfig): Configuration
         Returns:
            list of CheckSummary
 

--- a/tactus/submission.py
+++ b/tactus/submission.py
@@ -424,7 +424,7 @@ class NoSchedulerSubmission:
 
         Args:
             task                  (str): Task name
-            config (tactus.ParsedConfig): Config
+            config (ParsedConfig): Config
             template_job          (str): Task template job file
             task_job             (Path): Task job file
             output               (Path): Output file

--- a/tactus/suites/base.py
+++ b/tactus/suites/base.py
@@ -613,7 +613,7 @@ class EcflowSuiteTask(EcflowNode):
             parent (EcflowNode): Parent node.
             ecf_files (str): Path to ecflow containers
             task_settings (TaskSettings): Submission configuration
-            config (tactus.ParsedConfig): Configuration file
+            config (ParsedConfig): Configuration file
             task_settings (tactus.TaskSettings): Task settings
             input_template(str, optional): Input template
             parse (bool, optional): To parse template file or not

--- a/tactus/suites/compilation.py
+++ b/tactus/suites/compilation.py
@@ -18,7 +18,7 @@ class CompilationSuiteDefinition(SuiteDefinition):
         """Construct the definition.
 
         Args:
-            config (tactus.ParsedConfig): Configuration file
+            config (ParsedConfig): Configuration file
             dry_run (bool, optional): Dry run not using ecflow. Defaults to False.
 
         Raises:

--- a/tactus/suites/tactus.py
+++ b/tactus/suites/tactus.py
@@ -28,7 +28,7 @@ class TactusSuiteDefinition(SuiteDefinition):
         """Construct the definition.
 
         Args:
-            config (tactus.ParsedConfig): Configuration file
+            config (ParsedConfig): Configuration file
             dry_run (bool, optional): Dry run not using ecflow. Defaults to False.
 
         Raises:

--- a/tactus/tasks/addpert.py
+++ b/tactus/tasks/addpert.py
@@ -15,7 +15,7 @@ class Addpert(Task):
         """Construct Addpert object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         Task.__init__(self, config, __class__.__name__)
 

--- a/tactus/tasks/archive.py
+++ b/tactus/tasks/archive.py
@@ -24,7 +24,7 @@ class ArchiveStaticMember(ArchiveTask):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         ArchiveTask.__init__(self, config, "staticmember")
 
@@ -36,7 +36,7 @@ class ArchiveStatic(ArchiveTask):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         ArchiveTask.__init__(self, config, "static")
 
@@ -48,7 +48,7 @@ class ArchiveHour(ArchiveTask):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         ArchiveTask.__init__(self, config, "hour", exclude=["fdb"])
 
@@ -60,7 +60,7 @@ class ArchiveFDB(ArchiveTask):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         ArchiveTask.__init__(self, config, "FDB", include=["fdb"])
 
@@ -72,6 +72,6 @@ class ArchiveMergedSQLites(ArchiveTask):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         ArchiveTask.__init__(self, config, "merged_sqlite", exclude=["fdb"])

--- a/tactus/tasks/base.py
+++ b/tactus/tasks/base.py
@@ -43,7 +43,7 @@ class Task(object):
         """Construct base task.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
             name (str): Task name
 
         Raises:
@@ -327,7 +327,7 @@ class UnitTest(Task):
         """Construct test task.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         Task.__init__(self, config, __class__.__name__)
 
@@ -339,6 +339,6 @@ class ReferenceCheck(Task):
         """Construct ReferenceCheck task.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         Task.__init__(self, config, __class__.__name__)

--- a/tactus/tasks/boundaries.py
+++ b/tactus/tasks/boundaries.py
@@ -20,7 +20,7 @@ class InterpolateBoundaries(Task):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         self.boundary = Boundary(config)
         name = (
@@ -155,7 +155,7 @@ class E927(InterpolateBoundaries):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         InterpolateBoundaries.__init__(self, config)
 
@@ -167,6 +167,6 @@ class C903(InterpolateBoundaries):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         InterpolateBoundaries.__init__(self, config)

--- a/tactus/tasks/c903light.py
+++ b/tactus/tasks/c903light.py
@@ -13,7 +13,7 @@ class C903Light(Task):
         """Construct C903Light object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         Task.__init__(self, config, __class__.__name__)
 

--- a/tactus/tasks/canari.py
+++ b/tactus/tasks/canari.py
@@ -11,7 +11,7 @@ class Canari(Task):
         """Construct canari object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
 
         """
         Task.__init__(self, config, __class__.__name__)

--- a/tactus/tasks/cleaning_tasks.py
+++ b/tactus/tasks/cleaning_tasks.py
@@ -11,7 +11,7 @@ class Cleaning(Task):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         Task.__init__(self, config, __class__.__name__)
 
@@ -39,7 +39,7 @@ class CycleCleaning(Cleaning):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         Cleaning.__init__(self, config)
         self.name = "CycleCleaning"
@@ -53,7 +53,7 @@ class PostMortem(Cleaning):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         Cleaning.__init__(self, config)
         self.name = "PostMortem"

--- a/tactus/tasks/collectlogs.py
+++ b/tactus/tasks/collectlogs.py
@@ -16,7 +16,7 @@ class CollectLogs(Task):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
             config_label (str,optional): Which data to search for
         """
         Task.__init__(self, config, __class__.__name__)
@@ -104,7 +104,7 @@ class CollectLogsStatic(CollectLogs):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         CollectLogs.__init__(self, config, "staticlogs")
 
@@ -116,6 +116,6 @@ class CollectLogsHour(CollectLogs):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         CollectLogs.__init__(self, config, "hourlogs")

--- a/tactus/tasks/compilation.py
+++ b/tactus/tasks/compilation.py
@@ -24,7 +24,7 @@ class IALClone(Task):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         Task.__init__(self, config, __class__.__name__)
 
@@ -54,7 +54,7 @@ class TactusBundleCreate(Task):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         Task.__init__(self, config, __class__.__name__)
 
@@ -166,7 +166,7 @@ class TactusBundleBuild(Task):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         Task.__init__(self, config, __class__.__name__)
 

--- a/tactus/tasks/creategrib.py
+++ b/tactus/tasks/creategrib.py
@@ -16,7 +16,7 @@ class GlGrib(Task):
         """Construct create grib object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
             name (str): Task name
         """
         Task.__init__(self, config, name)
@@ -181,7 +181,7 @@ class CreateGrib(GlGrib):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         GlGrib.__init__(self, config, __class__.__name__)
 
@@ -193,6 +193,6 @@ class CreateGribStatic(GlGrib):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         GlGrib.__init__(self, config, __class__.__name__)

--- a/tactus/tasks/e923.py
+++ b/tactus/tasks/e923.py
@@ -22,7 +22,7 @@ class E923(Task):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
             taskname (str): Enforced task name
         """
         name = __class__.__name__ if taskname is None else taskname
@@ -243,7 +243,7 @@ class PgdUpdate(Task):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
 
         """
         Task.__init__(self, config, __class__.__name__)
@@ -303,7 +303,7 @@ class E923Constant(E923):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         E923.__init__(self, config, "E923Constant")
 
@@ -328,7 +328,7 @@ class E923Monthly(E923):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         try:
             months = config["task.args.months"].split(",")

--- a/tactus/tasks/e923_update.py
+++ b/tactus/tasks/e923_update.py
@@ -19,7 +19,7 @@ class E923Update(Task):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         Task.__init__(self, config, __class__.__name__)
 

--- a/tactus/tasks/forecast.py
+++ b/tactus/tasks/forecast.py
@@ -28,7 +28,7 @@ class Forecast(PySurfexBaseTask):
         """Construct forecast object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         PySurfexBaseTask.__init__(self, config, __class__.__name__)
 
@@ -323,7 +323,7 @@ class PrepareCycle(Task):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
 
         """
         Task.__init__(self, config, self.__class__.__name__)
@@ -341,7 +341,7 @@ class FirstGuess(Task):
         """Construct FirstGuess object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
 
         """
         Task.__init__(self, config, __class__.__name__)

--- a/tactus/tasks/generatewfptabfile.py
+++ b/tactus/tasks/generatewfptabfile.py
@@ -18,7 +18,7 @@ class GenerateWfpTabFile(Task):
         """Construct GenerateWfpTabFile object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         Task.__init__(self, config, __class__.__name__)
 

--- a/tactus/tasks/glbd.py
+++ b/tactus/tasks/glbd.py
@@ -17,7 +17,7 @@ class GlBd(Task):
         """Construct GlBd object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         Task.__init__(self, config, __class__.__name__)
 

--- a/tactus/tasks/gribmodify.py
+++ b/tactus/tasks/gribmodify.py
@@ -29,7 +29,7 @@ class AddCalculatedFields(Task):
         """Construct create grib object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         Task.__init__(self, config, __class__.__name__)
 

--- a/tactus/tasks/interpolsstsic.py
+++ b/tactus/tasks/interpolsstsic.py
@@ -21,7 +21,7 @@ class InterpolSstSic(Task):
         """Construct InterpolSstSic object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         Task.__init__(self, config, __class__.__name__)
 

--- a/tactus/tasks/iomerge.py
+++ b/tactus/tasks/iomerge.py
@@ -21,7 +21,7 @@ class IOmerge(Task):
         """Construct IOmerge object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         Task.__init__(self, config, __class__.__name__)
 

--- a/tactus/tasks/marsprep.py
+++ b/tactus/tasks/marsprep.py
@@ -46,7 +46,7 @@ class Marsprep(Task):
         """Construct forecast object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
 
         Raises:
             ValueError: No data for this date.

--- a/tactus/tasks/prep_run.py
+++ b/tactus/tasks/prep_run.py
@@ -21,7 +21,7 @@ class PrepRun(Task):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         self.name = "PrepRun"
         Task.__init__(self, config, __class__.__name__)

--- a/tactus/tasks/serial.py
+++ b/tactus/tasks/serial.py
@@ -11,7 +11,7 @@ class Serial(Task):
         """Construct serial task.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
         """
         logger.info("Construct serial task")
         Task.__init__(self, config, __class__.__name__)

--- a/tactus/tasks/sfx.py
+++ b/tactus/tasks/sfx.py
@@ -104,7 +104,7 @@ class Pgd(PySurfexBaseTask):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
 
         """
         PySurfexBaseTask.__init__(self, config, __class__.__name__)
@@ -167,7 +167,7 @@ class Prep(PySurfexBaseTask):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
 
         """
         PySurfexBaseTask.__init__(self, config, __class__.__name__)
@@ -274,7 +274,7 @@ class PgdFilterTownFrac(Task):
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
 
         """
         Task.__init__(self, config, __class__.__name__)

--- a/tactus/tasks/sqlite.py
+++ b/tactus/tasks/sqlite.py
@@ -24,7 +24,7 @@ class ExtractSQLite(Task):
         """Construct ExtractSQLite object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
 
         Raises:
             FileNotFoundError: Required file not fount
@@ -120,7 +120,7 @@ class MergeSQLites(Task):
         """Construct ExtractSQLite object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
 
         Raises:
             FileNotFoundError: Required file not found

--- a/tactus/tasks/toposoil.py
+++ b/tactus/tasks/toposoil.py
@@ -280,7 +280,7 @@ class Soil(Task):
         """Construct soil data object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
 
         """
         self.domain = get_domain(config)

--- a/tactus/toolbox.py
+++ b/tactus/toolbox.py
@@ -36,7 +36,7 @@ class Provider:
         """Construct the object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
             identifier (str): Identifier string
             fetch (bool, optional): Fetch data. Defaults to False.
 
@@ -79,7 +79,7 @@ class Platform:
         """Construct object.
 
         Args:
-            config (tactus.ParsedConfig): Config.
+            config (ParsedConfig): Config.
 
         """
         self.config = config
@@ -691,7 +691,7 @@ class FileManager:
         """Construct the object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
 
         """
         self.config = config
@@ -1016,7 +1016,7 @@ class LocalFileSystemSymlink(Provider):
         """Construct the object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
             pattern (str): Identifier string
             fetch (bool, optional): Fetch data. Defaults to True.
 
@@ -1058,7 +1058,7 @@ class LocalFileSystemCopy(Provider):
         """Construct the object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
             pattern (str): Identifier string
             fetch (bool, optional): Fetch data. Defaults to False.
 
@@ -1102,7 +1102,7 @@ class LocalFileSystemMove(Provider):
         """Construct the object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
             pattern (str): Identifier string
             fetch (bool, optional): Fetch data. Defaults to False.
 
@@ -1146,7 +1146,7 @@ class ArchiveProvider(Provider):
         """Construct the object.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
             pattern (str): Filepattern
             fetch (bool, optional): Fetch the data. Defaults to True.
 
@@ -1173,7 +1173,7 @@ class ECFS(ArchiveProvider):
         """Construct ECFS provider.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
             pattern (str): Filepattern
             fetch (bool, optional): Fetch the data. Defaults to True.
         """
@@ -1206,7 +1206,7 @@ class SCP(ArchiveProvider):
         """Construct SCP provider.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
             pattern (str): Filepattern
             fetch (bool, optional): Fetch the data. Defaults to True.
         """
@@ -1260,7 +1260,7 @@ class FDB(ArchiveProvider):
         """Construct FDB provider.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
             pattern (str): Filepattern
             fetch (bool, optional): Fetch the data. Defaults to True.
         """
@@ -1477,7 +1477,7 @@ class Resource:
         """Construct resource.
 
         Args:
-            _config (tactus.ParsedConfig): Configuration
+            _config (ParsedConfig): Configuration
             identifier (str): Resource identifier
 
         """
@@ -1492,7 +1492,7 @@ class LocalFileOnDisk(Resource):
         """Construct local file on disk.
 
         Args:
-            config (tactus.ParsedConfig): Configuration
+            config (ParsedConfig): Configuration
             pattern (str): Identifier pattern
             basetime (datetime.datetime, optional): Base time. Defaults to None.
             validtime (datetime.datetime, optional): Valid time. Defaults to None.


### PR DESCRIPTION
## Describe your changes

This PF a proposal to fix https://github.com/ACCORD-NWP/tactus/issues/133 : Documentation: unify docstring of ParsedConfig.
 
With the changes in this PR, ParsedConfig is used everywhere in docstring.
 
## Type of change

Please delete options that are not relevant.
 [x] This change requires a documentation update