### PR TITLE
Revert tolerance sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update CY50t2 namelists for Harmonie-Arome CSC. [#115](https://github.com/ACCORD-NWP/tactus/pull/115) (@romick-knmi, @uandrae)
 
 ### Fixed
+- Correct sign of the xtool error tolerance used in the referenceChecker. [#155](https://github.com/ACCORD-NWP/tactus/pull/155)(@uandrae)
 - Correct Marsprep bug for the SLAF case where the waitfor_files function was not working as expected. [#148](https://github.com/ACCORD-NWP/tactus/pull/148)(@uandrae)
 - Correct usage of STREAM=SCDA following ECMWF update to CY50r1 on 2026-05-12. [#142](https://github.com/ACCORD-NWP/tactus/pull/142)(@uandrae)
 - Fix empty steplist writing output every timestep instead of not at all. [#141](https://github.com/ACCORD-NWP/tactus/pull/141)(@kastelecn)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update CY50t2 namelists for Harmonie-Arome CSC. [#115](https://github.com/ACCORD-NWP/tactus/pull/115) (@romick-knmi, @uandrae)
 
 ### Fixed
-- Correct sign of the xtool error tolerance used in the referenceChecker. [#155](https://github.com/ACCORD-NWP/tactus/pull/155)(@uandrae)
+- Correct sign of the xtool error tolerance used in the referenceChecker. [#162](https://github.com/ACCORD-NWP/tactus/pull/162)(@uandrae)
 - Correct Marsprep bug for the SLAF case where the waitfor_files function was not working as expected. [#148](https://github.com/ACCORD-NWP/tactus/pull/148)(@uandrae)
 - Correct usage of STREAM=SCDA following ECMWF update to CY50r1 on 2026-05-12. [#142](https://github.com/ACCORD-NWP/tactus/pull/142)(@uandrae)
 - Fix empty steplist writing output every timestep instead of not at all. [#141](https://github.com/ACCORD-NWP/tactus/pull/141)(@kastelecn)

--- a/tactus/data/config_files/include/reference_checker.toml
+++ b/tactus/data/config_files/include/reference_checker.toml
@@ -24,21 +24,21 @@
   args_template = "-f1 {test_file} -f2 {reference_file} {file_format} -s -of SCREEN -de -to {tolerance}"
   binary = "@INSTALL_DIR@/gl/@COMPILER@/latest/bin/xtool"
   file_format = "GRIB"
-  tolerance = "10"
+  tolerance = "-10"
   tool = "xtool"
 
 [reference_checker.methods.HistoryFields]
   args_template = "-f1 {test_file} -f2 {reference_file} {file_format} -s -of SCREEN -de -to {tolerance}"
   binary = "@INSTALL_DIR@/gl/@COMPILER@/latest/bin/xtool"
   file_format = "FA"
-  tolerance = "10"
+  tolerance = "-10"
   tool = "xtool"
 
 [reference_checker.methods.E923Files]
   args_template = "-f1 {test_file} -f2 {reference_file} {file_format} -s -of SCREEN -de -to {tolerance} -igd"
   binary = "@INSTALL_DIR@/gl/@COMPILER@/latest/bin/xtool"
   file_format = "FA"
-  tolerance = "10"
+  tolerance = "-10"
   tool = "xtool"
 
 [reference_checker.summary.json]


### PR DESCRIPTION
## Describe your changes
The `tolerance` implemented for xtool has been implemented with the wrong sign by mistake. In xtool the maximum difference `zeps` between two fields is defined in https://github.com/ACCORD-NWP/gl/blob/master/prg/xtool.F90#L356. In HarmonieCSC ( CY49T2h ) -12 is used so we could possibly change to use this instead. What's the equivalent value in DAVAI, is such exists?


< Summary of the changes.>

< Please also include relevant motivation and context. >

< List any dependencies that are required for this change. >

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

### Testing

- [ ] I have tested this on ATOS using the `atos_bologna.toml` configuration in the latest version of [Tactus-test-runner](https://github.com/destination-earth-digital-twins/Tactus-test-runner)
- [ ] I have tested this on LUMI using the `lumi.toml` configuration in the latest version of [Tactus-test-runner](https://github.com/destination-earth-digital-twins/Tactus-test-runner)

For further information see the [development guide](https://github.com/ACCORD-NWP/tactus/blob/develop/docs/markdown_docs/development_guide.md)

### Code quality

- [ ] My change follows the [best practices for this project](https://github.com/ACCORD-NWP/tactus/blob/develop/docs/markdown_docs/development_guide.md#best-practices).
- [ ] My local environment is correctly initialised as described in the [README](https://github.com/ACCORD-NWP/tactus/blob/develop/README.md) file.
- [ ] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation and docstrings to reflect the changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have ensured that the code is still installable with `poetry` after the changes and runs
- [ ] I have requested one or more reviewer(s) and an assignee (assignee is responsible for merging). At least one reviewer has accepted to review.

## Checklist for reviewers
Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code readable
- [ ] the code well tested (checked coverage report)
- [ ] the code documented
- [ ] the code easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change (in section
  reflecting type of change, for example "bug fixes", add section where
  missing)

## Checklist for assignees
- [ ] PR is up to date with the base branch
- [ ] the tests passing
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- [ ] the PR has been approved by all the reviewers, that accepted to review.
- Once the PR ready to be merged, squash commits and merge the PR.

## Tag possible reviewers
You can @-tag people to review this PR in addition to formal review requests.
