### PR TITLE
Set surfex_sea_ice default none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update CY50t2 namelists for Harmonie-Arome CSC. [#115](https://github.com/ACCORD-NWP/tactus/pull/115) (@romick-knmi, @uandrae)
+- Set surfex_sea_ice to default none to be consistent for all CSCs. [#164](https://github.com/ACCORD-NWP/tactus/pull/164)(@uandrae)
 
 ### Fixed
 - Correct LBC file search pattern in the referenceChecker. [#163](https://github.com/ACCORD-NWP/tactus/pull/163)(@uandrae)

--- a/tactus/data/config_files/config_file_schemas/main_config_schema.json
+++ b/tactus/data/config_files/config_file_schemas/main_config_schema.json
@@ -1153,7 +1153,7 @@
             "sice",
             "none"
           ],
-          "default": "sice"
+          "default": "none"
         }
       },
       "required": [


### PR DESCRIPTION
## Describe your changes
In the config we have `general.surfex_sea_ice` with default value `sice`. This is used for two things:

- To activate the right sea ice scheme in surfex, `CSEAICE_SCHEME: "SICE"` or `NONE`. In practice it is only enabled for HARMONIE-AROME in `assemble_surfex.yml`
```
prep_HARMONIE_AROME:
  - sfx_prep_sea_@SURFEX_SEA_ICE@
```
- To correct SST under ice for SST/SIC update during the forecast. From tactus/tasks/interpolsstsic.py.
```
            # ADJUST_SST_UNDER_ICE must be TRUE only if sice is used
            adjust_sst_under_ice = (
                ".TRUE." if self.config["general.surfex_sea_ice"] == "sice" else ".FALSE."
            )
```
In the current develop we have `sice` for ALL CSCs although it should only be set for HARMONIE-AROME. This will change the result for ALARO and AROME and should probably be checked in DEODE ( although impact is expected small in the absense of sea ice :-).


< Please also include relevant motivation and context. >

< List any dependencies that are required for this change. >

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

### Testing

- [ ] I have tested this on ATOS using the `atos_bologna.toml` configuration in the latest version of [Tactus-test-runner](https://github.com/destination-earth-digital-twins/Tactus-test-runner)
- [ ] I have tested this on LUMI using the `lumi.toml` configuration in the latest version of [Tactus-test-runner](https://github.com/destination-earth-digital-twins/Tactus-test-runner)

For further information see the [development guide](https://github.com/ACCORD-NWP/tactus/blob/develop/docs/markdown_docs/development_guide.md)

### Code quality

- [ ] My change follows the [best practices for this project](https://github.com/ACCORD-NWP/tactus/blob/develop/docs/markdown_docs/development_guide.md#best-practices).
- [ ] My local environment is correctly initialised as described in the [README](https://github.com/ACCORD-NWP/tactus/blob/develop/README.md) file.
- [ ] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation and docstrings to reflect the changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have ensured that the code is still installable with `poetry` after the changes and runs
- [ ] I have requested one or more reviewer(s) and an assignee (assignee is responsible for merging). At least one reviewer has accepted to review.

## Checklist for reviewers
Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code readable
- [ ] the code well tested (checked coverage report)
- [ ] the code documented
- [ ] the code easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change (in section
  reflecting type of change, for example "bug fixes", add section where
  missing)

## Checklist for assignees
- [ ] PR is up to date with the base branch
- [ ] the tests passing
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- [ ] the PR has been approved by all the reviewers, that accepted to review.
- Once the PR ready to be merged, squash commits and merge the PR.

## Tag possible reviewers
You can @-tag people to review this PR in addition to formal review requests.
