### PR TITLE
Mandatory config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/destination-earth-digital-twins/Deode-Prototype/tree/HEAD)
 
+
+### Changed
+- Mandatory config file. [#171](https://github.com/ACCORD-NWP/tactus/pull/171) (@dhaumont)
+
 ## [1.3.0] - 2026-07-24
 
 ### Added

--- a/tactus/argparse_wrapper.py
+++ b/tactus/argparse_wrapper.py
@@ -49,9 +49,7 @@ def get_common_parser():
         default=ConfigParserDefaults.CONFIG_PATH,
         type=Path,
         required=True,
-        help=(
-            "Path to the config file."
-        ),
+        help=("Path to the config file."),
     )
     common_parser.add_argument(
         "--host-file",

--- a/tactus/argparse_wrapper.py
+++ b/tactus/argparse_wrapper.py
@@ -48,15 +48,9 @@ def get_common_parser():
         metavar="CONFIG_FILE_PATH",
         default=ConfigParserDefaults.CONFIG_PATH,
         type=Path,
+        required=True,
         help=(
-            "Path to the config file. The default is whichever of the "
-            + "following is first encountered: "
-            + "(i) The value of the 'TACTUS_CONFIG_PATH' envvar or "
-            + "(ii) './config.toml'. If both (i) and (ii) are missing, "
-            + "then the default will become "
-            + "'"
-            + f"{ConfigParserDefaults.PACKAGE_CONFIG_PATH}"
-            + "'"
+            "Path to the config file."
         ),
     )
     common_parser.add_argument(

--- a/tests/smoke/test_main.py
+++ b/tests/smoke/test_main.py
@@ -182,7 +182,7 @@ def test_run_task_command(tmp_path):
         f"{tmp_path.as_posix()}/forecast.log",
         "--create-only",
         "--config-file",
-        ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix()
+        ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix(),
     ])
 
 
@@ -192,7 +192,7 @@ def test_remove_command(tmp_path):
         "remove",
         "unexisting_file",
         "--config-file",
-        ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix()
+        ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix(),
     ])
 
 
@@ -200,7 +200,12 @@ def test_remove_command(tmp_path):
 def test_start_suite_command():
     os.environ["TACTUS_HOST"] = "atos_bologna"
     with suppress(FileNotFoundError, HostNotFoundError, ConfigFileValidationError):
-        main(["start", "suite", "--config-file", ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix()])
+        main([
+            "start",
+            "suite",
+            "--config-file",
+            ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix(),
+        ])
     del os.environ["TACTUS_HOST"]
 
 
@@ -208,14 +213,25 @@ def test_start_suite_command():
 def test_replace_node_command():
     os.environ["TACTUS_HOST"] = "atos_bologna"
     with suppress(FileNotFoundError, HostNotFoundError, ConfigFileValidationError):
-        main(["replace", "--ecf-node", "/", "--config-file", ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix()])
+        main([
+            "replace",
+            "--ecf-node",
+            "/",
+            "--config-file",
+            ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix(),
+        ])
     del os.environ["TACTUS_HOST"]
 
 
 @pytest.mark.usefixtures("_module_mockers")
 def test_doc_config_command():
     with redirect_stdout(StringIO()):
-        main(["doc", "config", "--config-file", ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix()])
+        main([
+            "doc",
+            "config",
+            "--config-file",
+            ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix(),
+        ])
 
 
 def test_integrate_namelists_command():
@@ -227,7 +243,7 @@ def test_integrate_namelists_command():
         "--output",
         os.devnull,
         "--config-file",
-        ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix()
+        ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix(),
     ]
     main(args)
 
@@ -250,7 +266,7 @@ def test_convert_namelists_command(tmp_path):
         "--format",
         "yaml",
         "--config-file",
-        ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix()
+        ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix(),
     ]
     main(args)
 
@@ -269,6 +285,6 @@ def test_format_namelists_command(tmp_path):
         "--format",
         "yaml",
         "--config-file",
-        ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix()
+        ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix(),
     ]
     main(args)

--- a/tests/smoke/test_main.py
+++ b/tests/smoke/test_main.py
@@ -111,8 +111,10 @@ def test_correct_config_is_in_use(config_path, mocker):
 @pytest.mark.usefixtures("_module_mockers")
 class TestMainShowCommands:
     def test_show_config_command(self):
-        with redirect_stdout(StringIO()):
+        with pytest.raises(SystemExit), redirect_stdout(StringIO()):
             main(["show", "config"])
+
+        with redirect_stdout(StringIO()):
             main([
                 "show",
                 "config",
@@ -122,8 +124,15 @@ class TestMainShowCommands:
             ])
 
     def test_show_config_schema_command(self):
-        with redirect_stdout(StringIO()):
+        with pytest.raises(SystemExit), redirect_stdout(StringIO()):
             main(["show", "config-schema"])
+        with redirect_stdout(StringIO()):
+            main([
+                "show",
+                "config-schema",
+                "--config-file",
+                ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix(),
+            ])
 
     def test_show_config_command_stretched_time(self):
         """Test again, mocking time.time so the total elapsed time is greater than 60s."""
@@ -136,11 +145,27 @@ class TestMainShowCommands:
             mock.patch("time.time", mock.MagicMock(side_effect=fake_time())),
             redirect_stdout(StringIO()),
         ):
-            main(["show", "config"])
+            main([
+                "show",
+                "config",
+                "--config-file",
+                ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix(),
+            ])
 
     def test_show_namelist_command(self, tmp_path_factory):
         output_file = f"{tmp_path_factory.getbasetemp().as_posix()}/fort.4"
-        main(["show", "namelist", "-t", "surfex", "-n", "forecast", "-o", output_file])
+        main([
+            "show",
+            "namelist",
+            "-t",
+            "surfex",
+            "-n",
+            "forecast",
+            "-o",
+            output_file,
+            "--config-file",
+            ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix(),
+        ])
 
 
 @pytest.mark.usefixtures("_module_mockers")

--- a/tests/smoke/test_main.py
+++ b/tests/smoke/test_main.py
@@ -181,6 +181,8 @@ def test_run_task_command(tmp_path):
         "-o",
         f"{tmp_path.as_posix()}/forecast.log",
         "--create-only",
+        "--config-file",
+        ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix()
     ])
 
 
@@ -189,6 +191,8 @@ def test_remove_command(tmp_path):
     main([
         "remove",
         "unexisting_file",
+        "--config-file",
+        ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix()
     ])
 
 
@@ -196,7 +200,7 @@ def test_remove_command(tmp_path):
 def test_start_suite_command():
     os.environ["TACTUS_HOST"] = "atos_bologna"
     with suppress(FileNotFoundError, HostNotFoundError, ConfigFileValidationError):
-        main(["start", "suite"])
+        main(["start", "suite", "--config-file", ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix()])
     del os.environ["TACTUS_HOST"]
 
 
@@ -204,14 +208,14 @@ def test_start_suite_command():
 def test_replace_node_command():
     os.environ["TACTUS_HOST"] = "atos_bologna"
     with suppress(FileNotFoundError, HostNotFoundError, ConfigFileValidationError):
-        main(["replace", "--ecf-node", "/"])
+        main(["replace", "--ecf-node", "/", "--config-file", ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix()])
     del os.environ["TACTUS_HOST"]
 
 
 @pytest.mark.usefixtures("_module_mockers")
 def test_doc_config_command():
     with redirect_stdout(StringIO()):
-        main(["doc", "config"])
+        main(["doc", "config", "--config-file", ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix()])
 
 
 def test_integrate_namelists_command():
@@ -222,6 +226,8 @@ def test_integrate_namelists_command():
         "tactus/data/namelists/unit_testing/nl_master_base",
         "--output",
         os.devnull,
+        "--config-file",
+        ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix()
     ]
     main(args)
 
@@ -243,6 +249,8 @@ def test_convert_namelists_command(tmp_path):
         "CY49t2",
         "--format",
         "yaml",
+        "--config-file",
+        ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix()
     ]
     main(args)
 
@@ -260,5 +268,7 @@ def test_format_namelists_command(tmp_path):
         output_yml,
         "--format",
         "yaml",
+        "--config-file",
+        ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix()
     ]
     main(args)


### PR DESCRIPTION
## Describe your changes

This PR is a tentative bug fix for https://github.com/ACCORD-NWP/tactus/issues/173.

We remove the default behavior for `tactus case` without arguments, and force to provide a config file from the command line

```
$ tactus case
2026-07-27 11:35:51 | INFO     | Start tactus v1.0.0 --> "tactus case"
usage: tactus case [-h] [--tactus-home TACTUS_HOME] --config-file CONFIG_FILE_PATH [--host-file HOST_FILE] [--config-data-dir CONFIG_DATA_DIR [CONFIG_DATA_DIR ...]] [--output OUTPUT_FILE] [--case-name CASE] [--start-suite]
                   [--keep-def-file] [--expand-config]
                   [config_mods ...]
tactus case: error: the following arguments are required: --config-file/-c
```
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

### Testing

- [ ] I have tested this on ATOS using the `atos_bologna.toml` configuration in the latest version of [Tactus-test-runner](https://github.com/destination-earth-digital-twins/Tactus-test-runner)
- [ ] I have tested this on LUMI using the `lumi.toml` configuration in the latest version of [Tactus-test-runner](https://github.com/destination-earth-digital-twins/Tactus-test-runner)

For further information see the [development guide](https://github.com/ACCORD-NWP/tactus/blob/develop/docs/markdown_docs/development_guide.md)

### Code quality

- [ ] My change follows the [best practices for this project](https://github.com/ACCORD-NWP/tactus/blob/develop/docs/markdown_docs/development_guide.md#best-practices).
- [ ] My local environment is correctly initialised as described in the [README](https://github.com/ACCORD-NWP/tactus/blob/develop/README.md) file.
- [ ] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation and docstrings to reflect the changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have ensured that the code is still installable with `poetry` after the changes and runs
- [ ] I have requested one or more reviewer(s) and an assignee (assignee is responsible for merging). At least one reviewer has accepted to review.

## Checklist for reviewers
Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code readable
- [ ] the code well tested (checked coverage report)
- [ ] the code documented
- [ ] the code easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change (in section
  reflecting type of change, for example "bug fixes", add section where
  missing)

## Checklist for assignees
- [ ] PR is up to date with the base branch
- [ ] the tests passing
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- [ ] the PR has been approved by all the reviewers, that accepted to review.
- Once the PR ready to be merged, squash commits and merge the PR.

## Tag possible reviewers
You can @-tag people to review this PR in addition to formal review requests.
