### PR TITLE
Make config-file mandatory for some commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/destination-earth-digital-twins/Deode-Prototype/tree/HEAD)
 
+### Changed
+- Make config-file mandatory for some commands. [#174](https://github.com/ACCORD-NWP/tactus/pull/174)(@dhaumont)
+
 ### Fixed
-- Don't check references when generating them [#175](https://github.com/ACCORD-NWP/tactus/pull/175)(@dhaumont)
+- Don't check references when generating them. [#175](https://github.com/ACCORD-NWP/tactus/pull/175)(@dhaumont)
 
 ## [1.3.0] - 2026-07-24
 

--- a/tactus/argparse_wrapper.py
+++ b/tactus/argparse_wrapper.py
@@ -27,7 +27,7 @@ from .namelist import NamelistConverter
 from .test_runner import run_test
 
 
-def get_common_parser(add_config_file=True):
+def get_common_parser(config_file_required=False):
     """Build and return the common argument parser shared by all subcommands.
 
     Returns:
@@ -42,7 +42,16 @@ def get_common_parser(add_config_file=True):
         default=None,
         help="Specify tactus_home to override automatic detection",
     )
-    if add_config_file:
+    if config_file_required:
+        common_parser.add_argument(
+            "--config-file",
+            "-c",
+            metavar="CONFIG_FILE_PATH",
+            required=True,
+            type=Path,
+            help=("Path to the config file."),
+        )
+    else:
         common_parser.add_argument(
             "--config-file",
             "-c",
@@ -88,8 +97,8 @@ def get_args_parser(program_name=GeneralConstants.PACKAGE_NAME):
         argparse.ArgumentParser: The configured argument parser.
 
     """
-    common_parser = get_common_parser()
-    common_parser_no_config_file = get_common_parser(add_config_file=False)
+    common_parser = get_common_parser(config_file_required=False)
+    common_parser_config_file_required = get_common_parser(config_file_required=True)
 
     ##########################################
     # Define main parser and general options #
@@ -189,16 +198,9 @@ def get_args_parser(program_name=GeneralConstants.PACKAGE_NAME):
     parser_case = subparsers.add_parser(
         "case",
         help="Create a config file to run an experiment case",
-        parents=[common_parser_no_config_file],
+        parents=[common_parser_config_file_required],
     )
-    parser_case.add_argument(
-        "--config-file",
-        "-c",
-        metavar="CONFIG_FILE_PATH",
-        required=True,
-        type=Path,
-        help="Path to the config file.",
-    )
+
     parser_case.add_argument(
         "--output",
         "-o",
@@ -252,18 +254,10 @@ def get_args_parser(program_name=GeneralConstants.PACKAGE_NAME):
 
     # suite
     parser_start_suite = start_command_subparsers.add_parser(
-        "suite", help="Start the suite", parents=[common_parser_no_config_file]
+        "suite", help="Start the suite", parents=[common_parser_config_file_required]
     )
     parser_start_suite.add_argument(
         "--start-command", type=str, help="Start command for server", default=None
-    )
-    parser_start_suite.add_argument(
-        "--config-file",
-        "-c",
-        metavar="CONFIG_FILE_PATH",
-        required=True,
-        type=Path,
-        help="Path to the config file.",
     )
 
     parser_start_suite.add_argument(

--- a/tactus/argparse_wrapper.py
+++ b/tactus/argparse_wrapper.py
@@ -27,7 +27,7 @@ from .namelist import NamelistConverter
 from .test_runner import run_test
 
 
-def get_common_parser():
+def get_common_parser(add_config_file=True):
     """Build and return the common argument parser shared by all subcommands.
 
     Returns:
@@ -42,23 +42,24 @@ def get_common_parser():
         default=None,
         help="Specify tactus_home to override automatic detection",
     )
-    common_parser.add_argument(
-        "--config-file",
-        "-c",
-        metavar="CONFIG_FILE_PATH",
-        default=ConfigParserDefaults.CONFIG_PATH,
-        type=Path,
-        help=(
-            "Path to the config file. The default is whichever of the "
-            + "following is first encountered: "
-            + "(i) The value of the 'TACTUS_CONFIG_PATH' envvar or "
-            + "(ii) './config.toml'. If both (i) and (ii) are missing, "
-            + "then the default will become "
-            + "'"
-            + f"{ConfigParserDefaults.PACKAGE_CONFIG_PATH}"
-            + "'"
-        ),
-    )
+    if add_config_file:
+        common_parser.add_argument(
+            "--config-file",
+            "-c",
+            metavar="CONFIG_FILE_PATH",
+            default=ConfigParserDefaults.CONFIG_PATH,
+            type=Path,
+            help=(
+                "Path to the config file. The default is whichever of the "
+                + "following is first encountered: "
+                + "(i) The value of the 'TACTUS_CONFIG_PATH' envvar or "
+                + "(ii) './config.toml'. If both (i) and (ii) are missing, "
+                + "then the default will become "
+                + "'"
+                + f"{ConfigParserDefaults.PACKAGE_CONFIG_PATH}"
+                + "'"
+            ),
+        )
     common_parser.add_argument(
         "--host-file",
         dest="host_file",
@@ -88,6 +89,7 @@ def get_args_parser(program_name=GeneralConstants.PACKAGE_NAME):
 
     """
     common_parser = get_common_parser()
+    common_parser_no_config_file = get_common_parser(add_config_file=False)
 
     ##########################################
     # Define main parser and general options #
@@ -187,7 +189,15 @@ def get_args_parser(program_name=GeneralConstants.PACKAGE_NAME):
     parser_case = subparsers.add_parser(
         "case",
         help="Create a config file to run an experiment case",
-        parents=[common_parser],
+        parents=[common_parser_no_config_file],
+    )
+    parser_case.add_argument(
+        "--config-file",
+        "-c",
+        metavar="CONFIG_FILE_PATH",
+        required=True,
+        type=Path,
+        help="Path to the config file.",
     )
     parser_case.add_argument(
         "--output",
@@ -242,11 +252,20 @@ def get_args_parser(program_name=GeneralConstants.PACKAGE_NAME):
 
     # suite
     parser_start_suite = start_command_subparsers.add_parser(
-        "suite", help="Start the suite", parents=[common_parser]
+        "suite", help="Start the suite", parents=[common_parser_no_config_file]
     )
     parser_start_suite.add_argument(
         "--start-command", type=str, help="Start command for server", default=None
     )
+    parser_start_suite.add_argument(
+        "--config-file",
+        "-c",
+        metavar="CONFIG_FILE_PATH",
+        required=True,
+        type=Path,
+        help="Path to the config file.",
+    )
+
     parser_start_suite.add_argument(
         "--def-file",
         "-f",

--- a/tactus/argparse_wrapper.py
+++ b/tactus/argparse_wrapper.py
@@ -30,6 +30,8 @@ from .test_runner import run_test
 def get_common_parser(config_file_required=False):
     """Build and return the common argument parser shared by all subcommands.
 
+    Args:
+        config_file_required (bool): Whether the config file argument is required.
     Returns:
         argparse.ArgumentParser: Parser with common arguments (config-file,
             host-file, etc.).

--- a/tactus/argparse_wrapper.py
+++ b/tactus/argparse_wrapper.py
@@ -32,6 +32,7 @@ def get_common_parser(config_file_required=False):
 
     Args:
         config_file_required (bool): Whether the config file argument is required.
+
     Returns:
         argparse.ArgumentParser: Parser with common arguments (config-file,
             host-file, etc.).

--- a/tests/smoke/test_main.py
+++ b/tests/smoke/test_main.py
@@ -171,7 +171,12 @@ def test_remove_command(tmp_path):
 def test_start_suite_command():
     os.environ["TACTUS_HOST"] = "atos_bologna"
     with suppress(FileNotFoundError, HostNotFoundError, ConfigFileValidationError):
-        main(["start", "suite"])
+        main([
+            "start",
+            "suite",
+            "--config-file",
+            ConfigParserDefaults.PACKAGE_CONFIG_PATH.as_posix(),
+        ])
     del os.environ["TACTUS_HOST"]
 
 


### PR DESCRIPTION
## Describe your changes
This PR is a tentative fix for : https://github.com/ACCORD-NWP/tactus/issues/173

We make the argument --config-file optional for all the commands (as before) but mandatory for `tactus case` and `tactus start suite`

< Summary of the changes.>

< Please also include relevant motivation and context. >

< List any dependencies that are required for this change. >

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

### Testing

- [ ] I have tested this on ATOS using the `atos_bologna.toml` configuration in the latest version of [Tactus-test-runner](https://github.com/destination-earth-digital-twins/Tactus-test-runner)
- [ ] I have tested this on LUMI using the `lumi.toml` configuration in the latest version of [Tactus-test-runner](https://github.com/destination-earth-digital-twins/Tactus-test-runner)

For further information see the [development guide](https://github.com/ACCORD-NWP/tactus/blob/develop/docs/markdown_docs/development_guide.md)

### Code quality

- [ ] My change follows the [best practices for this project](https://github.com/ACCORD-NWP/tactus/blob/develop/docs/markdown_docs/development_guide.md#best-practices).
- [ ] My local environment is correctly initialised as described in the [README](https://github.com/ACCORD-NWP/tactus/blob/develop/README.md) file.
- [ ] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation and docstrings to reflect the changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have ensured that the code is still installable with `poetry` after the changes and runs
- [ ] I have requested one or more reviewer(s) and an assignee (assignee is responsible for merging). At least one reviewer has accepted to review.

## Checklist for reviewers
Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code readable
- [ ] the code well tested (checked coverage report)
- [ ] the code documented
- [ ] the code easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change (in section
  reflecting type of change, for example "bug fixes", add section where
  missing)

## Checklist for assignees
- [ ] PR is up to date with the base branch
- [ ] the tests passing
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- [ ] the PR has been approved by all the reviewers, that accepted to review.
- Once the PR ready to be merged, squash commits and merge the PR.

## Tag possible reviewers
You can @-tag people to review this PR in addition to formal review requests.
